### PR TITLE
CICD: Prevent duplicate reviewers from same group in auto-assignment logic

### DIFF
--- a/.github/actions/auto-assign-reviewer/dist/index.js
+++ b/.github/actions/auto-assign-reviewer/dist/index.js
@@ -43,6 +43,12 @@ function getReviewers() {
     const data = (0, fs_1.readFileSync)(path, "utf-8");
     return JSON.parse(data);
 }
+function addReviewerFromGroup(groupCandidates, existingReviewers, part, selected) {
+    if (groupCandidates.every((candidate) => !existingReviewers.has(candidate.github))) {
+        if (groupCandidates.length > 0)
+            selected.push({ ...selectRandom(groupCandidates), part });
+    }
+}
 function detectChangedGroups(files) {
     let front = false;
     let back = false;
@@ -91,17 +97,11 @@ async function getCandidates(token) {
     const selected = [];
     if (groupFlags.front) {
         const candidates = reviewersData.front.filter((r) => r.github !== prAuthor);
-        if (candidates.some((candidate) => !existingReviewers.has(candidate.github))) {
-            if (candidates.length > 0)
-                selected.push({ ...selectRandom(candidates), part: "FE" });
-        }
+        addReviewerFromGroup(candidates, existingReviewers, "FE", selected);
     }
     if (groupFlags.back) {
         const candidates = reviewersData.back.filter((r) => r.github !== prAuthor);
-        if (candidates.some((candidate) => !existingReviewers.has(candidate.github))) {
-            if (candidates.length > 0)
-                selected.push({ ...selectRandom(candidates), part: "BE" });
-        }
+        addReviewerFromGroup(candidates, existingReviewers, "BE", selected);
     }
     return selected;
 }

--- a/.github/actions/auto-assign-reviewer/src/index.ts
+++ b/.github/actions/auto-assign-reviewer/src/index.ts
@@ -11,6 +11,22 @@ function getReviewers(): ReviewerGroup {
   return JSON.parse(data) as ReviewerGroup;
 }
 
+function addReviewerFromGroup(
+  groupCandidates: Reviewer[],
+  existingReviewers: Set<string>,
+  part: "FE" | "BE",
+  selected: Reviewer[]
+): void {
+  if (
+    groupCandidates.every(
+      (candidate) => !existingReviewers.has(candidate.github)
+    )
+  ) {
+    if (groupCandidates.length > 0)
+      selected.push({ ...selectRandom(groupCandidates), part });
+  }
+}
+
 function detectChangedGroups(files: string[]): {
   front: boolean;
   back: boolean;
@@ -69,7 +85,7 @@ async function getCandidates(token: string): Promise<Reviewer[]> {
   const reviewersData = getReviewers();
 
   // Reviewer 있으면 하지 말기
-  const existingReviewers = new Set(
+  const existingReviewers = new Set<string>(
     pr.requested_reviewers
       .map((r: { login: string }) => r.login)
       .filter((r: string) => !r.includes("[bot]"))
@@ -79,22 +95,12 @@ async function getCandidates(token: string): Promise<Reviewer[]> {
 
   if (groupFlags.front) {
     const candidates = reviewersData.front.filter((r) => r.github !== prAuthor);
-    if (
-      !candidates.some((candidate) => existingReviewers.has(candidate.github))
-    ) {
-      if (candidates.length > 0)
-        selected.push({ ...selectRandom(candidates), part: "FE" });
-    }
+    addReviewerFromGroup(candidates, existingReviewers, "FE", selected);
   }
 
   if (groupFlags.back) {
     const candidates = reviewersData.back.filter((r) => r.github !== prAuthor);
-    if (
-      !candidates.some((candidate) => existingReviewers.has(candidate.github))
-    ) {
-      if (candidates.length > 0)
-        selected.push({ ...selectRandom(candidates), part: "BE" });
-    }
+    addReviewerFromGroup(candidates, existingReviewers, "BE", selected);
   }
 
   return selected;

--- a/.github/actions/auto-assign-reviewer/src/index.ts
+++ b/.github/actions/auto-assign-reviewer/src/index.ts
@@ -80,7 +80,7 @@ async function getCandidates(token: string): Promise<Reviewer[]> {
   if (groupFlags.front) {
     const candidates = reviewersData.front.filter((r) => r.github !== prAuthor);
     if (
-      candidates.some((candidate) => !existingReviewers.has(candidate.github))
+      !candidates.some((candidate) => existingReviewers.has(candidate.github))
     ) {
       if (candidates.length > 0)
         selected.push({ ...selectRandom(candidates), part: "FE" });
@@ -90,7 +90,7 @@ async function getCandidates(token: string): Promise<Reviewer[]> {
   if (groupFlags.back) {
     const candidates = reviewersData.back.filter((r) => r.github !== prAuthor);
     if (
-      candidates.some((candidate) => !existingReviewers.has(candidate.github))
+      !candidates.some((candidate) => existingReviewers.has(candidate.github))
     ) {
       if (candidates.length > 0)
         selected.push({ ...selectRandom(candidates), part: "BE" });


### PR DESCRIPTION
## 🔀 PR: 리뷰어 자동 할당 시 그룹 중복 방지 로직 수정

### 📌 관련 이슈

* fixes #8

### 🛠 변경 내용

* 리뷰어 자동 할당 로직을 수정하여,
  **프론트엔드(FE)나 백엔드(BE) 그룹 중 기존 리뷰어가 한 명이라도 있는 경우 해당 그룹에서는 리뷰어를 추가하지 않도록 변경**하였습니다.

### 🔄 기존 로직

```js
if (
  candidates.some((candidate) => !existingReviewers.has(candidate.github))
)
```

* 그룹 내 일부가 리뷰어가 아니라면, 또 다른 리뷰어를 추가할 수 있었음.

### ✅ 변경 후 로직

```js
if (
  !candidates.some((candidate) => existingReviewers.has(candidate.github))
)
```

* 그룹 내에 기존 리뷰어가 **한 명도 없을 때만** 새 리뷰어를 무작위로 한 명 추가함.

### 🎯 목적

* 동일한 그룹(FE/BE) 내에서 **리뷰어 중복 지정 방지**
* PR 리뷰어 분배의 **균형성과 명확성 향상**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 리뷰어 자동 할당 로직이 개선되어, 프론트엔드 또는 백엔드 그룹에서 기존 리뷰어가 없는 경우에만 새로운 후보가 할당됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->