### PR TITLE
Feat/21 make domain

### DIFF
--- a/src/main/java/com/handongapp/cms/domain/AuditingFields.java
+++ b/src/main/java/com/handongapp/cms/domain/AuditingFields.java
@@ -15,15 +15,15 @@ import lombok.*;
 
 @Getter
 @ToString
-@EntityListeners(AuditingEntityListener.class) //이게 있어야 자동으로 값 넣어줌!!
+@EntityListeners(AuditingEntityListener.class)
 @MappedSuperclass
 public class AuditingFields {
     @Id
     @Column(columnDefinition = "CHAR(32)")
     private String id;
 
-    @Column(nullable = false) //이거는 테이블 컬럼에 속성을 주기 위함 입니다!! not null!!!!
     @Setter
+    @Column(columnDefinition = "CHAR(1)", nullable = false)
     protected String deleted;
 
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)

--- a/src/main/java/com/handongapp/cms/domain/AuditingFields.java
+++ b/src/main/java/com/handongapp/cms/domain/AuditingFields.java
@@ -19,25 +19,22 @@ import lombok.*;
 @MappedSuperclass
 public class AuditingFields {
     @Id
+    @Column(length = 32)
     private String id;
 
     @Column(nullable = false) //이거는 테이블 컬럼에 속성을 주기 위함 입니다!! not null!!!!
     @Setter
     protected String deleted;
 
-    @Column(nullable = true)
-    @Setter
-    protected String process;
-
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     @CreatedDate
     @Column(nullable = false, updatable = false)
-    protected LocalDateTime createdAt; // 생성일시
+    protected LocalDateTime createdAt;
 
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     @LastModifiedDate
     @Column(nullable = false)
-    protected LocalDateTime modifiedAt; // 수정일시
+    protected LocalDateTime updatedAt;
 
     @PrePersist
     public void onPrePersist() {

--- a/src/main/java/com/handongapp/cms/domain/AuditingFields.java
+++ b/src/main/java/com/handongapp/cms/domain/AuditingFields.java
@@ -19,7 +19,7 @@ import lombok.*;
 @MappedSuperclass
 public class AuditingFields {
     @Id
-    @Column(length = 32)
+    @Column(columnDefinition = "CHAR(32)")
     private String id;
 
     @Column(nullable = false) //이거는 테이블 컬럼에 속성을 주기 위함 입니다!! not null!!!!

--- a/src/main/java/com/handongapp/cms/domain/TbCourse.java
+++ b/src/main/java/com/handongapp/cms/domain/TbCourse.java
@@ -1,0 +1,36 @@
+package com.handongapp.cms.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "tb_course")
+@Getter
+@Setter
+@NoArgsConstructor
+public class TbCourse extends AuditingFields {
+    @Column(length = 32, nullable = false)
+    private String clubId;
+
+    @Column(length = 32, nullable = false)
+    private String userId;
+
+    @Column(length = 120, nullable = false)
+    private String title;
+
+    @Column(length = 100)
+    private String slug;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Column(length = 16, nullable = false)
+    private String visibility;
+
+    @Column(columnDefinition = "TEXT")
+    private String pictureUrl;
+}

--- a/src/main/java/com/handongapp/cms/domain/TbCourse.java
+++ b/src/main/java/com/handongapp/cms/domain/TbCourse.java
@@ -29,7 +29,7 @@ public class TbCourse extends AuditingFields {
     private String description;
 
     @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT TRUE")
-    private boolean isVisible;
+    private boolean isVisible = true;
 
     @Column(columnDefinition = "TEXT")
     private String pictureUrl;

--- a/src/main/java/com/handongapp/cms/domain/TbCourse.java
+++ b/src/main/java/com/handongapp/cms/domain/TbCourse.java
@@ -13,10 +13,10 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 public class TbCourse extends AuditingFields {
-    @Column(length = 32, nullable = false)
+    @Column(columnDefinition = "CHAR(32)", nullable = false)
     private String clubId;
 
-    @Column(length = 32, nullable = false)
+    @Column(columnDefinition = "CHAR(32)", nullable = false)
     private String userId;
 
     @Column(length = 120, nullable = false)

--- a/src/main/java/com/handongapp/cms/domain/TbCourse.java
+++ b/src/main/java/com/handongapp/cms/domain/TbCourse.java
@@ -28,8 +28,8 @@ public class TbCourse extends AuditingFields {
     @Column(columnDefinition = "TEXT")
     private String description;
 
-    @Column(length = 16, nullable = false)
-    private String visibility;
+    @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT TRUE")
+    private boolean isVisible;
 
     @Column(columnDefinition = "TEXT")
     private String pictureUrl;

--- a/src/main/java/com/handongapp/cms/domain/TbCourse.java
+++ b/src/main/java/com/handongapp/cms/domain/TbCourse.java
@@ -19,7 +19,7 @@ public class TbCourse extends AuditingFields {
     @Column(columnDefinition = "CHAR(32)", nullable = false)
     private String userId;
 
-    @Column(length = 120, nullable = false)
+    @Column(nullable = false)
     private String title;
 
     @Column(length = 100)

--- a/src/main/java/com/handongapp/cms/domain/TbProgramCourse.java
+++ b/src/main/java/com/handongapp/cms/domain/TbProgramCourse.java
@@ -1,0 +1,20 @@
+package com.handongapp.cms.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "tb_program_course")
+@Getter
+@Setter
+@NoArgsConstructor
+public class TbProgramCourse extends AuditingFields {
+    @Column(length = 32)
+    private String programId;
+    @Column(length = 32)
+    private String userId;
+}

--- a/src/main/java/com/handongapp/cms/domain/TbProgramCourse.java
+++ b/src/main/java/com/handongapp/cms/domain/TbProgramCourse.java
@@ -13,8 +13,8 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 public class TbProgramCourse extends AuditingFields {
-    @Column(length = 32)
+    @Column(columnDefinition = "CHAR(32)", nullable = false)
     private String programId;
-    @Column(length = 32)
+    @Column(columnDefinition = "CHAR(32)", nullable = false)
     private String userId;
 }

--- a/src/main/java/com/handongapp/cms/domain/TbProgramParticipant.java
+++ b/src/main/java/com/handongapp/cms/domain/TbProgramParticipant.java
@@ -15,10 +15,10 @@ import java.time.LocalDateTime;
 @Setter
 @NoArgsConstructor
 public class TbProgramParticipant extends AuditingFields {
+    @Column(columnDefinition = "CHAR(32)", nullable = false)
+    private String programId;
 
-    private Integer programId;
-
-    @Column(length = 32)
+    @Column(columnDefinition = "CHAR(32)", nullable = false)
     private String userId;
 
     private LocalDateTime invitedAt;

--- a/src/main/java/com/handongapp/cms/domain/TbProgramParticipant.java
+++ b/src/main/java/com/handongapp/cms/domain/TbProgramParticipant.java
@@ -1,0 +1,26 @@
+package com.handongapp.cms.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "tb_program_participant")
+@Getter
+@Setter
+@NoArgsConstructor
+public class TbProgramParticipant extends AuditingFields {
+
+    private Integer programId;
+
+    @Column(length = 32)
+    private String userId;
+
+    private LocalDateTime invitedAt;
+    private LocalDateTime acceptedAt;
+}

--- a/src/main/java/com/handongapp/cms/domain/TbProgramParticipant.java
+++ b/src/main/java/com/handongapp/cms/domain/TbProgramParticipant.java
@@ -21,6 +21,8 @@ public class TbProgramParticipant extends AuditingFields {
     @Column(columnDefinition = "CHAR(32)", nullable = false)
     private String userId;
 
+    @Column(columnDefinition = "DATETIME")
     private LocalDateTime invitedAt;
+    @Column(columnDefinition = "DATETIME")
     private LocalDateTime acceptedAt;
 }

--- a/src/main/java/com/handongapp/cms/domain/TbProgramProgress.java
+++ b/src/main/java/com/handongapp/cms/domain/TbProgramProgress.java
@@ -5,8 +5,6 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDateTime;
 
@@ -27,6 +25,7 @@ public class TbProgramProgress extends AuditingFields {
     @Column(length = 20)
     private ProgramProgressState state;
 
+    @Column(columnDefinition = "DATETIME")
     private LocalDateTime lastSeenAt;
 }
 

--- a/src/main/java/com/handongapp/cms/domain/TbProgramProgress.java
+++ b/src/main/java/com/handongapp/cms/domain/TbProgramProgress.java
@@ -1,0 +1,32 @@
+package com.handongapp.cms.domain;
+
+import com.handongapp.cms.domain.enums.ProgramProgressState;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "tb_program_progress")
+@Getter
+@Setter
+@NoArgsConstructor
+public class TbProgramProgress extends AuditingFields {
+    @Column(length = 32)
+    private String programId;
+    @Column(length = 32)
+    private String nodeGroupId;
+    @Column(length = 32)
+    private String userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 20)
+    private ProgramProgressState state;
+
+    private LocalDateTime lastSeenAt;
+}
+

--- a/src/main/java/com/handongapp/cms/domain/TbProgramProgress.java
+++ b/src/main/java/com/handongapp/cms/domain/TbProgramProgress.java
@@ -16,11 +16,11 @@ import java.time.LocalDateTime;
 @Setter
 @NoArgsConstructor
 public class TbProgramProgress extends AuditingFields {
-    @Column(length = 32)
+    @Column(columnDefinition = "CHAR(32)", nullable = false)
     private String programId;
-    @Column(length = 32)
+    @Column(columnDefinition = "CHAR(32)", nullable = false)
     private String nodeGroupId;
-    @Column(length = 32)
+    @Column(columnDefinition = "CHAR(32)", nullable = false)
     private String userId;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/handongapp/cms/domain/TbSection.java
+++ b/src/main/java/com/handongapp/cms/domain/TbSection.java
@@ -16,7 +16,7 @@ public class TbSection extends AuditingFields {
     @Column(columnDefinition = "CHAR(32)", nullable = false)
     private String courseId;
 
-    @Column(columnDefinition = "CHAR(32)", nullable = false)
+    @Column(columnDefinition = "CHAR(30)", nullable = false)
     private String title;
 
     @Column(columnDefinition = "TEXT")

--- a/src/main/java/com/handongapp/cms/domain/TbSection.java
+++ b/src/main/java/com/handongapp/cms/domain/TbSection.java
@@ -13,10 +13,10 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 public class TbSection extends AuditingFields {
-    @Column(length = 32, nullable = false)
+    @Column(columnDefinition = "CHAR(32)", nullable = false)
     private String courseId;
 
-    @Column(length = 30, nullable = false)
+    @Column(columnDefinition = "CHAR(32)", nullable = false)
     private String title;
 
     @Column(columnDefinition = "TEXT")

--- a/src/main/java/com/handongapp/cms/domain/TbSection.java
+++ b/src/main/java/com/handongapp/cms/domain/TbSection.java
@@ -1,0 +1,26 @@
+package com.handongapp.cms.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "tb_section")
+@Getter
+@Setter
+@NoArgsConstructor
+public class TbSection extends AuditingFields {
+    @Column(length = 32, nullable = false)
+    private String courseId;
+
+    @Column(length = 30, nullable = false)
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    private Integer order;
+}

--- a/src/main/java/com/handongapp/cms/domain/TbSection.java
+++ b/src/main/java/com/handongapp/cms/domain/TbSection.java
@@ -16,7 +16,7 @@ public class TbSection extends AuditingFields {
     @Column(columnDefinition = "CHAR(32)", nullable = false)
     private String courseId;
 
-    @Column(columnDefinition = "CHAR(30)", nullable = false)
+    @Column(nullable = false)
     private String title;
 
     @Column(columnDefinition = "TEXT")

--- a/src/main/java/com/handongapp/cms/domain/TbSection.java
+++ b/src/main/java/com/handongapp/cms/domain/TbSection.java
@@ -22,5 +22,6 @@ public class TbSection extends AuditingFields {
     @Column(columnDefinition = "TEXT")
     private String description;
 
+    @Column(name = "`order`")
     private Integer order;
 }

--- a/src/main/java/com/handongapp/cms/domain/enums/ProgramProgressState.java
+++ b/src/main/java/com/handongapp/cms/domain/enums/ProgramProgressState.java
@@ -1,0 +1,7 @@
+package com.handongapp.cms.domain.enums;
+
+public enum ProgramProgressState {
+    DONE,    // 모두 읽음
+    IN_PROGRESS, // 일부 진행
+    NOT_STARTED  // 시작 전
+}


### PR DESCRIPTION
## 📌 관련 이슈
Closes #21

---

## ✨ 작업 내용

- `TbCourse` 엔티티 추가
- `TbProgramCourse` 엔티티 추가
- `TbSection` 엔티티 추가
- `TbProgramParticipants` 엔티티 추가
- `TbProgramProgress` 엔티티 추가
- `AuditingFields.modifiedAt` → `updatedAt` 필드명 리팩토링 및 타입 설정 수정

---

## 🔎 세부 설명

- 모든 엔티티는 FK 없이 설계됨 (`@Column` 기반 명시적 매핑)
- UUID 기반 `char(32)` ID와 명확한 필드 타입 지정 (`varchar`, `text`, `datetime`, `enum` 등)
- `enum` 필드(`state`)는 향후 `@Enumerated(EnumType.STRING)` 적용을 위한 설계
- `AuditingFields`의 네이밍을 실무 관례에 맞춰 리팩토링
- 각 커밋은 엔티티 단위로 분리하여 추적 가능성 강화

---

## 📁 변경된 파일/폴더

- `domain/TbCourse.java`
- `domain/TbProgramCourse.java`
- `domain/TbSection.java`
- `domain/TbProgramParticipants.java`
- `domain/TbProgramProgress.java`
- `common/AuditingFields.java`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 강좌, 프로그램, 섹션, 참여자, 진행상태 등 다양한 엔티티가 추가되어 관리 기능이 확장되었습니다.
    - 프로그램 진행 상태를 나타내는 새로운 상태(enum)가 도입되었습니다.

- **버그 수정**
    - 일부 필드의 데이터베이스 컬럼 정의가 명확하게 지정되고 필수 여부가 조정되었습니다.

- **리팩터링**
    - 필드명 변경 및 주석 정리를 통해 코드 일관성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->