### PR TITLE
Feat/22 make domain

### DIFF
--- a/src/main/java/com/handongapp/cms/domain/TbComment.java
+++ b/src/main/java/com/handongapp/cms/domain/TbComment.java
@@ -1,0 +1,33 @@
+package com.example.course.domain;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+/**
+ * <p>TbComment Entity – user-generated comment bound to a Node.</p>
+ *
+ * <p><b>Design Pattern:</b> Aggregate Leaf of <i>Course</i>, managed via a Repository.</p>
+ */
+@Entity
+@Table(name = "tb_comment")
+public class TbComment extends AuditingFields{
+
+    /** Author – UUID */
+    @Column(name = "user_id", length = 32, nullable = false)
+    private String userId;
+
+    /** Indicates the target node has been deleted (soft-delete flag) */
+    @Column(name = "is_node_deleted")
+    private Boolean nodeDeleted;
+
+    /** Target Node (either a Node or, in special cases, a NodeGroup) */
+    @Column(name = "target_id")
+    private String targetId;
+
+    /** Comment category (emoji label etc.) */
+    @Column(name = "category_id")
+    private String categoryId;
+
+    @Lob
+    private String content;
+}

--- a/src/main/java/com/handongapp/cms/domain/TbComment.java
+++ b/src/main/java/com/handongapp/cms/domain/TbComment.java
@@ -13,7 +13,7 @@ import java.time.LocalDateTime;
 public class TbComment extends AuditingFields{
 
     /** Author – UUID */
-    @Column(name = "user_id", length = 32, nullable = false)
+    @Column(name = "user_id",columnDefinition = "char(32)", nullable = false)
     private String userId;
 
     /** Indicates the target node has been deleted (soft-delete flag) */
@@ -21,11 +21,11 @@ public class TbComment extends AuditingFields{
     private Boolean nodeDeleted;
 
     /** Target Node (either a Node or, in special cases, a NodeGroup) */
-    @Column(name = "target_id")
+    @Column(name = "target_id",columnDefinition = "char(32)", nullable = false)
     private String targetId;
 
     /** Comment category (emoji label etc.) */
-    @Column(name = "category_id")
+    @Column(name = "category_id",columnDefinition = "char(32)", nullable = false)
     private String categoryId;
 
     @Lob

--- a/src/main/java/com/handongapp/cms/domain/TbComment.java
+++ b/src/main/java/com/handongapp/cms/domain/TbComment.java
@@ -1,7 +1,5 @@
-package com.example.course.domain;
-
+package com.handongapp.cms.domain;
 import jakarta.persistence.*;
-import java.time.LocalDateTime;
 
 /**
  * <p>TbComment Entity – user-generated comment bound to a Node.</p>
@@ -10,7 +8,7 @@ import java.time.LocalDateTime;
  */
 @Entity
 @Table(name = "tb_comment")
-public class TbComment extends AuditingFields{
+public class TbComment extends AuditingFields {
 
     /** Author – UUID */
     @Column(name = "user_id",columnDefinition = "char(32)", nullable = false)

--- a/src/main/java/com/handongapp/cms/domain/TbCommentCategory.java
+++ b/src/main/java/com/handongapp/cms/domain/TbCommentCategory.java
@@ -1,0 +1,30 @@
+package com.example.course.domain;
+
+import jakarta.persistence.*;
+
+/**
+ * <p>TbCommentCategory Entity – per-course configurable set of comment
+ *   categories (slug, i18n label, emoji).</p>
+ *
+ * <p><b>Design Pattern:</b> Reference Data / Lookup Table.</p>
+ */
+@Entity
+@Table(name = "tb_comment_category")
+public class TbCommentCategory extends AuditingFields {
+
+    /** FK → course.id (BIGINT) */
+    @Column(name = "course_id", nullable = false)
+    private String courseId;
+
+    /** URL-friendly unique key */
+    @Column(length = 100, nullable = false)
+    private String slug;
+
+    /** Localized display name */
+    @Column(length = 64)
+    private String label;
+
+    /** Emoji code-point(s) – max 10 chars */
+    @Column(length = 10)
+    private String emoji;
+}

--- a/src/main/java/com/handongapp/cms/domain/TbCommentOfCategory.java
+++ b/src/main/java/com/handongapp/cms/domain/TbCommentOfCategory.java
@@ -7,8 +7,12 @@ import jakarta.persistence.*;
  *
  * <p><b>Design Pattern:</b> Reference Data / Lookup Table.</p>
  */
+@Getter
+@Setter
 @Entity
-@Table(name = "tb_comment_of_category")
+@Table(name = "tb_comment_of_category",uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"course_id", "slug"})
+})
 public class TbCommentOfCategory extends AuditingFields {
 
     /** FK → course.id (BIGINT) */

--- a/src/main/java/com/handongapp/cms/domain/TbCommentOfCategory.java
+++ b/src/main/java/com/handongapp/cms/domain/TbCommentOfCategory.java
@@ -1,5 +1,4 @@
-package com.example.course.domain;
-
+package com.handongapp.cms.domain;
 import jakarta.persistence.*;
 
 /**

--- a/src/main/java/com/handongapp/cms/domain/TbCommentOfCategory.java
+++ b/src/main/java/com/handongapp/cms/domain/TbCommentOfCategory.java
@@ -3,17 +3,17 @@ package com.example.course.domain;
 import jakarta.persistence.*;
 
 /**
- * <p>TbCommentCategory Entity – per-course configurable set of comment
+ * <p>TbCommentOfCategory Entity – per-course configurable set of comment
  *   categories (slug, i18n label, emoji).</p>
  *
  * <p><b>Design Pattern:</b> Reference Data / Lookup Table.</p>
  */
 @Entity
-@Table(name = "tb_comment_category")
-public class TbCommentCategory extends AuditingFields {
+@Table(name = "tb_comment_of_category")
+public class TbCommentOfCategory extends AuditingFields {
 
     /** FK → course.id (BIGINT) */
-    @Column(name = "course_id", nullable = false)
+    @Column(name = "course_id",columnDefinition = "char(32)", nullable = false)
     private String courseId;
 
     /** URL-friendly unique key */

--- a/src/main/java/com/handongapp/cms/domain/TbCourseLastView.java
+++ b/src/main/java/com/handongapp/cms/domain/TbCourseLastView.java
@@ -1,0 +1,28 @@
+package com.example.course.domain;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+/**
+ * <p>TbCourseLastView Entity – records the last node-group a user has viewed
+ *   in a given course.</p>
+ *
+ * <p><b>Design Pattern:</b> Plain Old Java Object, used as a JPA Aggregate Root.</p>
+ */
+@Entity
+@Table(name = "tb_course_last_view")
+public class TbCourseLastView extends AuditingFields {
+
+    /** Owner of the record – UUID (CHAR(32)) */
+    @Column(name = "user_id", length = 32, nullable = false)
+    private String userId;
+
+    /** Course identifier (FK → course.id) */
+    @Column(name = "course_id", nullable = false)
+    private Integer courseId;
+
+    /** Last viewed Node-Group */
+    @Column(name = "node_group_id", length = 32, nullable = false)
+    private String nodeGroupId;
+
+}

--- a/src/main/java/com/handongapp/cms/domain/TbCourseLastView.java
+++ b/src/main/java/com/handongapp/cms/domain/TbCourseLastView.java
@@ -14,15 +14,15 @@ import java.time.LocalDateTime;
 public class TbCourseLastView extends AuditingFields {
 
     /** Owner of the record – UUID (CHAR(32)) */
-    @Column(name = "user_id", length = 32, nullable = false)
+    @Column(name = "user_id",columnDefinition = "char(32)", nullable = false)
     private String userId;
 
     /** Course identifier (FK → course.id) */
-    @Column(name = "course_id", nullable = false)
-    private Integer courseId;
+    @Column(name = "course_id",columnDefinition = "char(32)", nullable = false)
+    private String courseId;
 
     /** Last viewed Node-Group */
-    @Column(name = "node_group_id", length = 32, nullable = false)
+    @Column(name = "node_group_id",columnDefinition = "char(32)", nullable = false)
     private String nodeGroupId;
 
 }

--- a/src/main/java/com/handongapp/cms/domain/TbCourseLastView.java
+++ b/src/main/java/com/handongapp/cms/domain/TbCourseLastView.java
@@ -1,7 +1,6 @@
-package com.example.course.domain;
+package com.handongapp.cms.domain;
 
 import jakarta.persistence.*;
-import java.time.LocalDateTime;
 
 /**
  * <p>TbCourseLastView Entity – records the last node-group a user has viewed

--- a/src/main/java/com/handongapp/cms/domain/TbNode.java
+++ b/src/main/java/com/handongapp/cms/domain/TbNode.java
@@ -1,6 +1,6 @@
-package com.example.course.domain;
+package com.handongapp.cms.domain;
 
-import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
+import com.vladmihalcea.hibernate.type.json.JsonStringType;
 import jakarta.persistence.*;
 import org.hibernate.annotations.Type;
 import java.util.Map;
@@ -36,17 +36,15 @@ public class TbNode extends AuditingFields {
     private Boolean commentPermitted = Boolean.FALSE;
 
     /** Arbitrary JSON payload – requires hibernate-types dependency */
-    @Type(JsonBinaryType.class)
-    @Column(columnDefinition = "jsonb")
+    @Type(JsonStringType.class)
+    @Column(columnDefinition = "json")
     private Map<String, Object> data;
-}
 
-/**
- * Enumerates the supported node types.
- */
-public enum NodeType {
-    TEXT,
-    IMAGE,
-    VIDEO,
-    QUIZ
+
+    private enum NodeType {
+        TEXT,
+        IMAGE,
+        VIDEO,
+        QUIZ
+    }
 }

--- a/src/main/java/com/handongapp/cms/domain/TbNode.java
+++ b/src/main/java/com/handongapp/cms/domain/TbNode.java
@@ -15,7 +15,7 @@ import java.util.Map;
 public class TbNode extends AuditingFields {
 
     /** Owning group */
-    @Column(name = "node_group_id")
+    @Column(name = "node_group_id",columnDefinition = "char(32)", nullable = false)
     private String nodeGroupId;
 
     /** Position inside the group */

--- a/src/main/java/com/handongapp/cms/domain/TbNode.java
+++ b/src/main/java/com/handongapp/cms/domain/TbNode.java
@@ -1,0 +1,52 @@
+package com.example.course.domain;
+
+import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
+import jakarta.persistence.*;
+import org.hibernate.annotations.Type;
+import java.util.Map;
+
+/**
+ * <p>TbNode Entity – single learning object (text, image, video, quiz…).</p>
+ *
+ * <p><b>Design Pattern:</b> Leaf of the Composite (NodeGroup).</p>
+ */
+@Entity
+@Table(name = "tb_node")
+public class TbNode extends AuditingFields {
+
+    /** Owning group */
+    @Column(name = "node_group_id")
+    private String nodeGroupId;
+
+    /** Position inside the group */
+    @Column(name = "`order`")
+    private Integer order;
+
+    /** Node content type */
+    @Enumerated(EnumType.STRING)
+    private NodeType type;
+
+    /** Optional attachment */
+    @Lob
+    @Column(name = "attachment_url")
+    private String attachmentUrl;
+
+    /** Whether comments are allowed for this node */
+    @Column(name = "is_comment_permitted")
+    private Boolean commentPermitted = Boolean.FALSE;
+
+    /** Arbitrary JSON payload – requires hibernate-types dependency */
+    @Type(JsonBinaryType.class)
+    @Column(columnDefinition = "jsonb")
+    private Map<String, Object> data;
+}
+
+/**
+ * Enumerates the supported node types.
+ */
+public enum NodeType {
+    TEXT,
+    IMAGE,
+    VIDEO,
+    QUIZ
+}

--- a/src/main/java/com/handongapp/cms/domain/TbNodeGroup.java
+++ b/src/main/java/com/handongapp/cms/domain/TbNodeGroup.java
@@ -1,4 +1,4 @@
-package com.example.course.domain;
+package com.handongapp.cms.domain;
 
 import jakarta.persistence.*;
 import java.util.ArrayList;

--- a/src/main/java/com/handongapp/cms/domain/TbNodeGroup.java
+++ b/src/main/java/com/handongapp/cms/domain/TbNodeGroup.java
@@ -15,12 +15,11 @@ import java.util.List;
 public class TbNodeGroup extends AuditingFields {
 
     /** Parent Section (UUID) */
-    @Column(name = "section_id", length = 32, nullable = false)
+    @Column(name = "section_id",columnDefinition = "char(32)", nullable = false)
     private String sectionId;
 
-    @Column(length = 32, nullable = false)
+    @Column(columnDefinition = "varchar(30)", nullable = false)
     private String title;
-
     /** Explicit sort order */
     @Column(name = "`order`")
     private Integer order;

--- a/src/main/java/com/handongapp/cms/domain/TbNodeGroup.java
+++ b/src/main/java/com/handongapp/cms/domain/TbNodeGroup.java
@@ -1,0 +1,27 @@
+package com.example.course.domain;
+
+import jakarta.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * <p>TbNodeGroup Entity – logical grouping of Nodes inside a Course Section.</p>
+ *
+ * <p><b>Design Pattern:</b> Composite pattern (NodeGroup is the composite,
+ *   Node is the leaf).</p>
+ */
+@Entity
+@Table(name = "tb_node_group")
+public class TbNodeGroup extends AuditingFields {
+
+    /** Parent Section (UUID) */
+    @Column(name = "section_id", length = 32, nullable = false)
+    private String sectionId;
+
+    @Column(length = 32, nullable = false)
+    private String title;
+
+    /** Explicit sort order */
+    @Column(name = "`order`")
+    private Integer order;
+}


### PR DESCRIPTION
## 📌 관련 이슈  
Closes #22

---

## ✨ 작업 내용  
- TbNodeGroup 엔티티 추가  
- TbNode 엔티티 추가  
- TbComment 엔티티 추가  
- TbCommentCategory 엔티티 추가  
- TbCourseLastView 엔티티 추가  
- 공통 베이스 `AuditingFields` 상속 적용  
- JSON 필드 타입 수정 (jsonb → json)  
- 컬럼 타입 및 패키지 경로 리팩터링

---

## 🔎 세부 설명  
- ERD에 기반해 5개의 도메인 엔티티를 `Tb` 접두어로 정의했습니다.  
- 모든 엔티티는 `AuditingFields`를 상속받아 `createdAt`, `updatedAt` 필드를 공통 관리합니다.  
- `TbNode`의 `data` 필드는 `json` 타입과 매핑되며, Hibernate의 `JsonType`으로 처리됩니다.  
- `refactor` 커밋을 통해 컬럼 타입 및 패키지 경로를 실제 DB 설계에 맞게 수정했습니다.  
- merge 작업을 통해 main 브랜치 변경 사항을 반영했습니다.

---

## 🧪 테스트  
- [x] Entity 클래스 빌드 성공 확인  
- [x] Hibernate 자동 DDL 생성 시 스키마 반영 확인  

---

## 📁 변경된 파일/폴더  
- `domain/TbNodeGroup.java`  
- `domain/TbNode.java`  
- `domain/TbComment.java`  
- `domain/TbCategoryOfComment.java`  
- `domain/TbCourseLastView.java`  
- `domain/AuditingFields.java`  

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 댓글 작성 및 관리 기능이 추가되었습니다.
    - 강좌별 댓글 카테고리(이모지 등) 설정 기능이 도입되었습니다.
    - 사용자의 강좌 내 마지막 열람 위치가 기록됩니다.
    - 텍스트, 이미지, 동영상, 퀴즈 등 다양한 유형의 학습 객체를 지원합니다.
    - 강좌 섹션 내 노드 그룹 관리 기능이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->