### PR TITLE
Refactor/38 api v1 package

### DIFF
--- a/src/main/java/com/handongapp/cms/auth/controller/GoogleLoginController.java
+++ b/src/main/java/com/handongapp/cms/auth/controller/GoogleLoginController.java
@@ -1,16 +1,15 @@
-package com.handongapp.cms.controller;
+package com.handongapp.cms.auth.controller;
 
-import com.handongapp.cms.security.AuthService;
+import com.handongapp.cms.auth.service.AuthService;
 import com.handongapp.cms.security.LoginProperties;
 import com.handongapp.cms.security.PrincipalDetails;
 import com.handongapp.cms.security.TokenBlacklistManager;
-import com.handongapp.cms.security.dto.GoogleOAuthResponse;
-import com.handongapp.cms.service.GoogleOAuthService;
+import com.handongapp.cms.auth.dto.GoogleOAuthResponse;
+import com.handongapp.cms.auth.service.GoogleOAuthService;
 import com.handongapp.cms.service.TbUserService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.util.UriComponentsBuilder;
 
 import java.util.Map;
 

--- a/src/main/java/com/handongapp/cms/auth/dto/GoogleOAuthResponse.java
+++ b/src/main/java/com/handongapp/cms/auth/dto/GoogleOAuthResponse.java
@@ -1,4 +1,4 @@
-package com.handongapp.cms.security.dto;
+package com.handongapp.cms.auth.dto;
 
 import com.handongapp.cms.domain.TbUser;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/handongapp/cms/auth/dto/GoogleTokenResponse.java
+++ b/src/main/java/com/handongapp/cms/auth/dto/GoogleTokenResponse.java
@@ -1,4 +1,4 @@
-package com.handongapp.cms.security.dto;
+package com.handongapp.cms.auth.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;

--- a/src/main/java/com/handongapp/cms/auth/dto/GoogleUserInfoResponse.java
+++ b/src/main/java/com/handongapp/cms/auth/dto/GoogleUserInfoResponse.java
@@ -1,4 +1,4 @@
-package com.handongapp.cms.security.dto;
+package com.handongapp.cms.auth.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/handongapp/cms/auth/service/AuthService.java
+++ b/src/main/java/com/handongapp/cms/auth/service/AuthService.java
@@ -1,4 +1,4 @@
-package com.handongapp.cms.security;
+package com.handongapp.cms.auth.service;
 
 import io.jsonwebtoken.Claims;
 

--- a/src/main/java/com/handongapp/cms/auth/service/GoogleOAuthService.java
+++ b/src/main/java/com/handongapp/cms/auth/service/GoogleOAuthService.java
@@ -1,6 +1,6 @@
-package com.handongapp.cms.service;
+package com.handongapp.cms.auth.service;
 
-import com.handongapp.cms.security.dto.GoogleOAuthResponse;
+import com.handongapp.cms.auth.dto.GoogleOAuthResponse;
 
 public interface GoogleOAuthService {
     GoogleOAuthResponse authenticate(String authorizationCode);

--- a/src/main/java/com/handongapp/cms/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/com/handongapp/cms/auth/service/impl/AuthServiceImpl.java
@@ -1,6 +1,9 @@
-package com.handongapp.cms.security;
+package com.handongapp.cms.auth.service.impl;
 
 import com.github.benmanes.caffeine.cache.Cache;
+import com.handongapp.cms.auth.service.AuthService;
+import com.handongapp.cms.security.LoginProperties;
+import com.handongapp.cms.security.TokenBlacklistManager;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
@@ -11,10 +14,9 @@ import java.security.Key;
 import java.time.Duration;
 import java.util.Date;
 import java.util.Map;
-import java.util.UUID;
 
 @Component
-public class AuthServiceImpl implements AuthService{
+public class AuthServiceImpl implements AuthService {
 
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
     private final LoginProperties loginProperties;

--- a/src/main/java/com/handongapp/cms/auth/service/impl/GoogleOAuthServiceImpl.java
+++ b/src/main/java/com/handongapp/cms/auth/service/impl/GoogleOAuthServiceImpl.java
@@ -1,13 +1,13 @@
-package com.handongapp.cms.service.impl;
+package com.handongapp.cms.auth.service.impl;
 
 import com.handongapp.cms.domain.TbUser;
 import com.handongapp.cms.repository.TbUserRepository;
-import com.handongapp.cms.security.AuthService;
+import com.handongapp.cms.auth.service.AuthService;
 import com.handongapp.cms.security.LoginProperties;
-import com.handongapp.cms.security.dto.GoogleOAuthResponse;
-import com.handongapp.cms.security.dto.GoogleTokenResponse;
-import com.handongapp.cms.security.dto.GoogleUserInfoResponse;
-import com.handongapp.cms.service.GoogleOAuthService;
+import com.handongapp.cms.auth.dto.GoogleOAuthResponse;
+import com.handongapp.cms.auth.dto.GoogleTokenResponse;
+import com.handongapp.cms.auth.dto.GoogleUserInfoResponse;
+import com.handongapp.cms.auth.service.GoogleOAuthService;
 import com.handongapp.cms.service.TbUserService;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/handongapp/cms/config/SecurityConfig.java
+++ b/src/main/java/com/handongapp/cms/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.handongapp.cms.config;
 
+import com.handongapp.cms.auth.service.impl.AuthServiceImpl;
 import com.handongapp.cms.security.*;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/com/handongapp/cms/controller/v1/NodeController.java
+++ b/src/main/java/com/handongapp/cms/controller/v1/NodeController.java
@@ -1,6 +1,6 @@
-package com.handongapp.cms.controller;
+package com.handongapp.cms.controller.v1;
 
-import com.handongapp.cms.dto.NodeDto;
+import com.handongapp.cms.dto.v1.NodeDto;
 import com.handongapp.cms.service.NodeService;
 //import com.handongapp.cms.service.validator.CourseHierarchyValidator;
 import jakarta.validation.Valid;

--- a/src/main/java/com/handongapp/cms/dto/v1/NodeDto.java
+++ b/src/main/java/com/handongapp/cms/dto/v1/NodeDto.java
@@ -1,4 +1,4 @@
-package com.handongapp.cms.dto;
+package com.handongapp.cms.dto.v1;
 
 import com.handongapp.cms.domain.TbNode;
 import jakarta.validation.constraints.NotNull;

--- a/src/main/java/com/handongapp/cms/security/JwtAuthorizationFilter.java
+++ b/src/main/java/com/handongapp/cms/security/JwtAuthorizationFilter.java
@@ -1,5 +1,6 @@
 package com.handongapp.cms.security;
 
+import com.handongapp.cms.auth.service.AuthService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;

--- a/src/main/java/com/handongapp/cms/service/NodeService.java
+++ b/src/main/java/com/handongapp/cms/service/NodeService.java
@@ -1,6 +1,6 @@
 package com.handongapp.cms.service;
 
-import com.handongapp.cms.dto.NodeDto;
+import com.handongapp.cms.dto.v1.NodeDto;
 
 import java.util.List;
 

--- a/src/main/java/com/handongapp/cms/service/TbUserService.java
+++ b/src/main/java/com/handongapp/cms/service/TbUserService.java
@@ -1,7 +1,7 @@
 package com.handongapp.cms.service;
 
 import com.handongapp.cms.domain.TbUser;
-import com.handongapp.cms.security.dto.GoogleUserInfoResponse;
+import com.handongapp.cms.auth.dto.GoogleUserInfoResponse;
 
 public interface TbUserService {
     TbUser saveOrUpdateUser(String userId, String email, String name);

--- a/src/main/java/com/handongapp/cms/service/impl/NodeServiceImpl.java
+++ b/src/main/java/com/handongapp/cms/service/impl/NodeServiceImpl.java
@@ -1,7 +1,7 @@
 package com.handongapp.cms.service.impl;
 
 import com.handongapp.cms.domain.TbNode;
-import com.handongapp.cms.dto.NodeDto;
+import com.handongapp.cms.dto.v1.NodeDto;
 import com.handongapp.cms.repository.TbNodeRepository;
 import com.handongapp.cms.service.NodeService;
 import com.handongapp.cms.service.validator.NodeDataValidator;

--- a/src/main/java/com/handongapp/cms/service/impl/TbUserServiceImpl.java
+++ b/src/main/java/com/handongapp/cms/service/impl/TbUserServiceImpl.java
@@ -5,7 +5,7 @@ import com.handongapp.cms.domain.TbUser;
 import com.handongapp.cms.domain.TbUserClubRole;
 import com.handongapp.cms.repository.TbUserClubRoleRepository;
 import com.handongapp.cms.repository.TbUserRepository;
-import com.handongapp.cms.security.dto.GoogleUserInfoResponse;
+import com.handongapp.cms.auth.dto.GoogleUserInfoResponse;
 import com.handongapp.cms.service.TbUserService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;


### PR DESCRIPTION
## 📌 관련 이슈  
Resolves #38

___

## ✨ 작업 내용  
- API 버전 관리를 위한 `controller`, `dto` 패키지 구조 정리  
- 인증 관련 로직들을 도메인 단위(`auth`)로 분리  

___

## 🔎 세부 설명  
- `NodeController` → `controller.v1`, `NodeDto` → `dto.v1`로 이동  
- 추후 `v2` 확장에 대비한 버전 분기 구조 도입  
- 인증 로직 관련 클래스들(`GoogleLoginController`, `AuthService`, `GoogleOAuthService`, 응답 DTO 등)을 `auth.controller`, `auth.service`, `auth.dto`로 이동하여 도메인 단위 구조 정립  
- 기존 `SecurityConfig`, `Filter`, `Service` 클래스에서 import 경로 전면 수정  
- 구조적 명확성과 유지보수성 향상 목적

___

## 🧪 테스트  
- [x] Node 생성/수정/조회/삭제 API 테스트 (`/v1` 경로 정상 작동 확인)  
- [x] Google OAuth 로그인 플로우 테스트 (JWT 발급 정상 동작) 
___

## 📁 변경된 파일/폴더  
- `controller/NodeController.java` → `controller/v1/NodeController.java`  
- `dto/NodeDto.java` → `dto/v1/NodeDto.java`  
- `GoogleLoginController.java` → `auth/controller/GoogleLoginController.java`  
- `GoogleOAuthResponse`, `GoogleTokenResponse`, `GoogleUserInfoResponse` → `auth/dto/`  
- `AuthService`, `GoogleOAuthService` → `auth/service/`, `auth/service/impl/`  
- 기존 import 전체 경로 변경

___

## ➕ 기타  
- 서비스 레이어는 현재는 v1 단일 구조 유지 (버전별 분리가 필요한 시점에 대응 예정)  
- 구조 리팩토링 중심이므로 기능 변경 없음