### PR TITLE
Feat/46 presigned url api

### DIFF
--- a/.bruno/bruno.json
+++ b/.bruno/bruno.json
@@ -5,5 +5,11 @@
   "ignore": [
     "node_modules",
     ".git"
-  ]
+  ],
+  "size": 0,
+  "filesCount": 0,
+  "presets": {
+    "requestType": "http",
+    "requestUrl": "http://localhost:{{PORT}}/api/"
+  }
 }

--- a/.bruno/environments/local.bru
+++ b/.bruno/environments/local.bru
@@ -1,0 +1,6 @@
+vars {
+  PORT: 8080
+}
+vars:secret [
+  ACCESS_TOKEN
+]

--- a/.bruno/v1/folder.bru
+++ b/.bruno/v1/folder.bru
@@ -1,0 +1,4 @@
+meta {
+  name: v1
+  seq: 2
+}

--- a/.bruno/v1/s3/Get download presigned url.bru
+++ b/.bruno/v1/s3/Get download presigned url.bru
@@ -1,0 +1,21 @@
+meta {
+  name: Get download presigned url
+  type: http
+  seq: 2
+}
+
+get {
+  url: http://localhost:{{PORT}}/api/v1/s3/download-url?filename=1748450057529-the_path.mp4
+  body: none
+  auth: inherit
+}
+
+params:query {
+  filename: 1748450057529-the_path.mp4
+}
+
+body:json {
+  {
+    "key": "1748450166785-the path.mp4"
+  }
+}

--- a/.bruno/v1/s3/Get upload presigned url.bru
+++ b/.bruno/v1/s3/Get upload presigned url.bru
@@ -1,0 +1,18 @@
+meta {
+  name: Get upload presigned url
+  type: http
+  seq: 1
+}
+
+post {
+  url: http://localhost:{{PORT}}/api/v1/s3/upload-url
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "filename": "1748193451965-cap-flow.mp4",
+    "contentType": "video/mp4"
+  }
+}

--- a/.bruno/v1/s3/Notify upload complete.bru
+++ b/.bruno/v1/s3/Notify upload complete.bru
@@ -1,0 +1,18 @@
+meta {
+  name: Notify upload complete
+  type: http
+  seq: 3
+}
+
+post {
+  url: http://localhost:{{PORT}}/api/v1/s3/upload-complete
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "filename": "1748450057529-the_path.mp4",
+    "filetype": "video"
+  }
+}

--- a/.bruno/v1/s3/folder.bru
+++ b/.bruno/v1/s3/folder.bru
@@ -1,0 +1,4 @@
+meta {
+  name: s3
+  seq: 1
+}

--- a/build.gradle
+++ b/build.gradle
@@ -86,6 +86,10 @@ dependencies {
 // MyBatis
     implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.3'
 
+//  For Message Queue
+    implementation 'org.springframework.boot:spring-boot-starter-amqp'
+
+
 //  hibernate Validator
     implementation 'org.hibernate.validator:hibernate-validator'
 

--- a/src/main/java/com/handongapp/cms/config/RabbitMQConfig.java
+++ b/src/main/java/com/handongapp/cms/config/RabbitMQConfig.java
@@ -1,0 +1,35 @@
+package com.handongapp.cms.config;
+
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.AmqpTemplate;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RabbitMQConfig {
+
+    @Value("${rabbitmq.queue.transcode-request}")
+    private String transcodeRequestQueue;
+
+    @Bean
+    public Queue transcodeRequestQueue() {
+        return new Queue(transcodeRequestQueue, true);
+    }
+
+    @Bean
+    public MessageConverter jsonMessageConverter() {
+        return new Jackson2JsonMessageConverter();
+    }
+
+    @Bean
+    public AmqpTemplate amqpTemplate(ConnectionFactory connectionFactory) {
+        RabbitTemplate template = new RabbitTemplate(connectionFactory);
+        template.setMessageConverter(jsonMessageConverter());
+        return template;
+    }
+}

--- a/src/main/java/com/handongapp/cms/controller/v1/S3Controller.java
+++ b/src/main/java/com/handongapp/cms/controller/v1/S3Controller.java
@@ -2,6 +2,7 @@ package com.handongapp.cms.controller.v1;
 
 import com.handongapp.cms.dto.v1.S3Dto;
 import com.handongapp.cms.service.PresignedUrlService;
+import com.handongapp.cms.service.UploadNotifyService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.*;
 public class S3Controller {
 
     private final PresignedUrlService presignedUrlService;
+    private final UploadNotifyService uploadNotifyService;
 
     @PostMapping("/upload-url")
     public ResponseEntity<S3Dto.UploadUrlResponse> generateUploadUrl(
@@ -21,6 +23,12 @@ public class S3Controller {
                         .presignedUrl(presignedUrlService.generateUploadUrl(request.getFilename(), request.getContentType()).toString())
                         .build()
         );
+    }
+
+    @PostMapping("/upload-complete")
+    public ResponseEntity<Void> notifyUploadComplete(@RequestBody S3Dto.UploadCompleteDto dto) {
+        uploadNotifyService.notifyUploadComplete(dto);
+        return ResponseEntity.ok().build();
     }
 
     @GetMapping("/download-url")

--- a/src/main/java/com/handongapp/cms/controller/v1/S3Controller.java
+++ b/src/main/java/com/handongapp/cms/controller/v1/S3Controller.java
@@ -1,0 +1,35 @@
+package com.handongapp.cms.controller.v1;
+
+import com.handongapp.cms.dto.v1.S3Dto;
+import com.handongapp.cms.service.PresignedUrlService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/s3")
+@RequiredArgsConstructor
+public class S3Controller {
+
+    private final PresignedUrlService presignedUrlService;
+
+    @PostMapping("/upload-url")
+    public ResponseEntity<S3Dto.UploadUrlResponse> generateUploadUrl(
+            @RequestBody S3Dto.UploadUrlRequest request) {
+        return ResponseEntity.ok(
+                S3Dto.UploadUrlResponse.builder()
+                        .presignedUrl(presignedUrlService.generateUploadUrl(request.getFilename(), request.getContentType()).toString())
+                        .build()
+        );
+    }
+
+    @GetMapping("/download-url")
+    public ResponseEntity<S3Dto.DownloadUrlResponse> generateDownloadUrl(
+            @RequestParam("filename") String filename) {
+        return ResponseEntity.ok(
+                S3Dto.DownloadUrlResponse.builder()
+                        .presignedUrl(presignedUrlService.generateDownloadUrl(filename).toString())
+                        .build()
+        );
+    }
+}

--- a/src/main/java/com/handongapp/cms/dto/v1/S3Dto.java
+++ b/src/main/java/com/handongapp/cms/dto/v1/S3Dto.java
@@ -1,0 +1,50 @@
+package com.handongapp.cms.dto.v1;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+public class S3Dto {
+    private S3Dto() {}
+
+    @Builder
+    @Schema
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class UploadUrlRequest {
+        private String filename;
+        private String contentType;
+    }
+
+    @Builder
+    @Schema
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class UploadUrlResponse {
+        private String presignedUrl;
+    }
+
+    @Builder
+    @Schema
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class UploadCompleteDto {
+        private String filename;
+        private String contentType;
+    }
+
+    @Builder
+    @Schema
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class DownloadUrlResponse {
+        private String presignedUrl;
+    }
+}

--- a/src/main/java/com/handongapp/cms/dto/v1/S3Dto.java
+++ b/src/main/java/com/handongapp/cms/dto/v1/S3Dto.java
@@ -35,7 +35,7 @@ public class S3Dto {
     @NoArgsConstructor
     public static class UploadCompleteDto {
         private String filename;
-        private String contentType;
+        private String filetype;
     }
 
     @Builder

--- a/src/main/java/com/handongapp/cms/service/PresignedUrlService.java
+++ b/src/main/java/com/handongapp/cms/service/PresignedUrlService.java
@@ -1,0 +1,9 @@
+package com.handongapp.cms.service;
+
+import java.net.URL;
+
+
+public interface PresignedUrlService {
+    URL generateUploadUrl(String filename, String contentType);
+    URL generateDownloadUrl(String key);
+}

--- a/src/main/java/com/handongapp/cms/service/UploadNotifyService.java
+++ b/src/main/java/com/handongapp/cms/service/UploadNotifyService.java
@@ -1,0 +1,8 @@
+package com.handongapp.cms.service;
+
+
+import com.handongapp.cms.dto.v1.S3Dto.UploadCompleteDto;
+
+public interface UploadNotifyService {
+    void notifyUploadComplete(UploadCompleteDto dto);
+}

--- a/src/main/java/com/handongapp/cms/service/impl/PresignedUrlServiceImpl.java
+++ b/src/main/java/com/handongapp/cms/service/impl/PresignedUrlServiceImpl.java
@@ -1,0 +1,75 @@
+package com.handongapp.cms.service.impl;
+
+import com.handongapp.cms.service.PresignedUrlService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Configuration;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+import java.net.URI;
+import java.net.URL;
+import java.time.Duration;
+
+@Service
+public class PresignedUrlServiceImpl implements PresignedUrlService {
+
+    private final S3Presigner presigner;
+    private final String bucket;
+
+    public PresignedUrlServiceImpl(
+            @Value("${cloud.aws.s3.bucket}") String bucket,
+            @Value("${cloud.aws.credentials.access-key}") String accessKey,
+            @Value("${cloud.aws.credentials.secret-key}") String secretKey,
+            @Value("${cloud.aws.endpoint}") String endpoint
+    ) {
+        this.bucket = bucket;
+
+        this.presigner = S3Presigner.builder()
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(accessKey, secretKey)))
+                .endpointOverride(URI.create(endpoint))
+                .region(Region.US_EAST_1)
+                .serviceConfiguration(S3Configuration.builder()
+                        .pathStyleAccessEnabled(true)
+                        .build())
+                .build();
+    }
+
+    @Override
+    public URL generateUploadUrl(String filename, String contentType) {
+        PutObjectRequest objectRequest = PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(filename)
+                .contentType(contentType)
+                .build();
+
+        PutObjectPresignRequest presignRequest = PutObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofMinutes(10))
+                .putObjectRequest(objectRequest)
+                .build();
+
+        return presigner.presignPutObject(presignRequest).url();
+    }
+
+    @Override
+    public URL generateDownloadUrl(String key) {
+        GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .build();
+
+        GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofMinutes(10))
+                .getObjectRequest(getObjectRequest)
+                .build();
+
+        return presigner.presignGetObject(presignRequest).url();
+    }
+}

--- a/src/main/java/com/handongapp/cms/service/impl/UploadNotifyServiceImpl.java
+++ b/src/main/java/com/handongapp/cms/service/impl/UploadNotifyServiceImpl.java
@@ -1,0 +1,31 @@
+package com.handongapp.cms.service.impl;
+
+import com.handongapp.cms.dto.v1.S3Dto.UploadCompleteDto;
+import com.handongapp.cms.service.UploadNotifyService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.core.AmqpTemplate;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UploadNotifyServiceImpl implements UploadNotifyService {
+
+    private final AmqpTemplate amqpTemplate;
+
+    @Value("${rabbitmq.queue.transcode-request}")
+    private String transcodeRequestQueue;
+
+    @Override
+    public void notifyUploadComplete(UploadCompleteDto dto) {
+        try {
+            // RabbitMQ 에게 메시지 전송
+            amqpTemplate.convertAndSend(transcodeRequestQueue, dto);
+            log.info("\uD83D\uDE80  Transcode request sent to RabbitMQ: {}", transcodeRequestQueue);
+        } catch (Exception e) {
+            log.error("❌ Failed to send message to RabbitMQ: {}", e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -22,13 +22,15 @@ spring:
 
 cloud:
   aws:
-    region:
-      static: ap-northeast-2
-    credentials:
-      accessKey: ${AWS_ACCESSKEY:${AWS_ACCESSKEY_DEFAULT}}
-      secretKey: ${AWS_SECRETKEY:${AWS_SECRETKEY_DEFAULT}}
     s3:
-      bucket: ${AWS_BUCKET_NAME:${AWS_BUCKET_NAME_DEFAULT}}
+      bucket: ${MINIO_BUCKET}
+    credentials:
+      access-key: ${MINIO_ACCESS_KEY_ID}
+      secret-key: ${MINIO_SECRET_ACCESS_KEY}
+    endpoint: ${MINIO_ENDPOINT}
+    region:
+      static: us-east-1
+    path-style-access-enabled: true
 
 google:
   oauth:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -32,6 +32,14 @@ cloud:
       static: us-east-1
     path-style-access-enabled: true
 
+rabbitmq:
+  queue:
+    transcode-request: ${TRANSCODE_REQUEST_QUEUE}
+  host: ${RABBITMQ_HOST}
+  port: ${RABBITMQ_PORT}
+  username: ${RABBITMQ_USERNAME}
+  password: ${RABBITMQ_PASSWORD}
+
 google:
   oauth:
     client-id: ${OAUTH_GOOGLE_CLIENT_ID:${OAUTH_GOOGLE_CLIENT_ID_DEFAULT}}


### PR DESCRIPTION
## 📌 관련 이슈
* Resolves #46

___ 

## ✨ 작업 내용
- Presigned Upload URL API 추가
- Upload 완료 시 백엔드에 알리는 Upload Complete API 추가
- 업로드 완료 API 수신시 RabbitMQ를 통해 트랜스코드 요청 발송
- 트랜스코드 큐 설정 및 AMQP 통합 설정 추가

___ 

## 🔎 세부 설명
- `/api/v1/s3/upload-url`: 업로드를 위한 Presigned URL을 생성하여 응답
- `/api/v1/s3/upload-complete`: 업로드 완료 후 호출되며, RabbitMQ로 트랜스코드 요청 파이프라인 트리거
- RabbitMQ 설정 (`application.yaml` 및 `RabbitMQConfig`)
  - `spring-boot-starter-amqp` 의존성 추가
  - Jackson 기반 메시지 직렬화 설정
- RabbitTemplate을 통해 `transcode-request` 큐로 메시지 전송
- 메시지를 수신한 Python 컨슈머가 Celery 태스크를 생성하여 트랜스코드 실행

___ 

## 🧪 테스트
- [x] 브루노에서 Presigned Upload URL 발급 API 호출 성공
- [x] 업로드 완료 후 `/upload-complete` 호출 시 큐 전송 확인
- [x] FastAPI에서 트랜스코드 요청 수신 및 작업 시작 확인
- [x] Redis Pub/Sub로 진행률 수신 확인

___ 

## 📁 변경된 파일/폴더
- `PresignedUrlServiceImpl.java`
- `UploadNotifyServiceImpl.java`
- `RabbitMQConfig.java`
- `S3Controller.java`
- `application.yaml`

___ 

## ➕ 기타
- 업로드~트랜스코드 전체 파이프라인이 단일 API 흐름으로 연결됨
- 트랜스코드 진행률 Redis Pub/Sub으로 프론트에 실시간 전달 구현예정
- 영상 스트리밍 URL 제공 예정