### PR TITLE
Feat/89/add login time

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -63,7 +63,7 @@ external:
     access:
       prefix: Authorization
       secret: ${JWT_ACCESS_SECRET:${JWT_ACCESS_SECRET_DEFAULT}}
-      expiration-ms: 900000      # 15?
+      expiration-ms: 86400000      # 1일?
     refresh:
       prefix: refreshToken
       secret: ${JWT_REFRESH_SECRET:${JWT_REFRESH_SECRET_DEFAULT}}


### PR DESCRIPTION
로그인 시간 늘리기


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - JWT 액세스 토큰의 만료 시간이 15분에서 1일로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->