### PR TITLE
✨ Feat: api/v1/node-group/next endpoint

### DIFF
--- a/.bruno/v1/node-group/nodeGroupNext.bru
+++ b/.bruno/v1/node-group/nodeGroupNext.bru
@@ -5,11 +5,15 @@ meta {
 }
 
 get {
-  url: {{BASE_URL_LOCAL}}/api/v1/node-group/{{nodeGroupId}}
+  url: {{BASE_URL_LOCAL}}/api/v1/node-group/next?nodeGroupId={{nodeGroupId}}
   body: none
   auth: inherit
 }
 
+params:query {
+  nodeGroupId: {{nodeGroupId}}
+}
+
 vars:pre-request {
-  nodeGroupId: nodg0000000000000000000000000002
+  nodeGroupId: nodg0000000000000000000000000001
 }

--- a/.bruno/v1/node-group/nodeGroupNext.bru
+++ b/.bruno/v1/node-group/nodeGroupNext.bru
@@ -1,0 +1,15 @@
+meta {
+  name: nodeGroupNext
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{BASE_URL_LOCAL}}/api/v1/node-group/{{nodeGroupId}}
+  body: none
+  auth: inherit
+}
+
+vars:pre-request {
+  nodeGroupId: nodg0000000000000000000000000002
+}

--- a/src/main/java/com/handongapp/cms/controller/v1/NodeGroupController.java
+++ b/src/main/java/com/handongapp/cms/controller/v1/NodeGroupController.java
@@ -2,6 +2,9 @@ package com.handongapp.cms.controller.v1;
 
 import com.handongapp.cms.dto.v1.NodeGroupDto;
 import com.handongapp.cms.service.NodeGroupService;
+
+import jakarta.validation.constraints.NotBlank;
+
 import java.util.Collections; 
 import java.util.Optional;    
 import lombok.RequiredArgsConstructor;
@@ -59,7 +62,7 @@ public class NodeGroupController {
     // }
 
     @GetMapping("/next")
-    public ResponseEntity<?> getNextNodeGroupInfo(@RequestParam String nodeGroupId) {
+    public ResponseEntity<?> getNextNodeGroupInfo(@RequestParam @NotBlank String nodeGroupId) {
         Optional<NodeGroupDto.NextNodeGroupResponseDto> nextNodeGroupData = nodeGroupService.getNextNodeGroupInSectionOrCourse(nodeGroupId);
         return nextNodeGroupData.<ResponseEntity<?>>map(ResponseEntity::ok)
                 .orElseGet(() -> ResponseEntity.ok(Collections.emptyMap()));

--- a/src/main/java/com/handongapp/cms/controller/v1/NodeGroupController.java
+++ b/src/main/java/com/handongapp/cms/controller/v1/NodeGroupController.java
@@ -1,6 +1,9 @@
 package com.handongapp.cms.controller.v1;
 
+import com.handongapp.cms.dto.v1.NodeGroupDto;
 import com.handongapp.cms.service.NodeGroupService;
+import java.util.Collections; 
+import java.util.Optional;    
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -54,4 +57,11 @@ public class NodeGroupController {
     //     nodeGroupService.deleteSoft(nodeGroupId);
     //     return ResponseEntity.noContent().build();
     // }
+
+    @GetMapping("/next")
+    public ResponseEntity<?> getNextNodeGroupInfo(@RequestParam String nodeGroupId) {
+        Optional<NodeGroupDto.NextNodeGroupResponseDto> nextNodeGroupData = nodeGroupService.getNextNodeGroupInSectionOrCourse(nodeGroupId);
+        return nextNodeGroupData.<ResponseEntity<?>>map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.ok(Collections.emptyMap()));
+    }
 }

--- a/src/main/java/com/handongapp/cms/dto/v1/NodeGroupDto.java
+++ b/src/main/java/com/handongapp/cms/dto/v1/NodeGroupDto.java
@@ -1,6 +1,8 @@
 package com.handongapp.cms.dto.v1;
 
 import com.handongapp.cms.domain.TbNodeGroup;
+import com.handongapp.cms.domain.TbSection;
+
 import jakarta.validation.constraints.NotBlank;
 import lombok.Data;
 import java.time.LocalDateTime;
@@ -8,6 +10,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.Builder;
 
 public class NodeGroupDto {
 
@@ -105,5 +108,42 @@ public class NodeGroupDto {
     public static class NodeGroupBaseDto {
         private String title;
         private Integer order;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class NextNodeGroupResponseDto {
+        // Section Info
+        private String sectionId;
+        private String sectionTitle;
+        private Integer sectionOrder;
+        private String sectionCourseId;
+        private LocalDateTime sectionCreatedAt;
+        private LocalDateTime sectionUpdatedAt;
+
+        // NodeGroup Info
+        private String nodeGroupId;
+        private String nodeGroupTitle;
+        private Integer nodeGroupOrder;
+        private LocalDateTime nodeGroupCreatedAt;
+        private LocalDateTime nodeGroupUpdatedAt;
+
+        public static NextNodeGroupResponseDto buildResponseDto(TbSection section, TbNodeGroup nodeGroup) {
+            return NextNodeGroupResponseDto.builder()
+                .sectionId(section.getId())
+                .sectionTitle(section.getTitle())
+                .sectionOrder(section.getOrder().intValue())
+                .sectionCourseId(section.getCourseId())
+                .sectionCreatedAt(section.getCreatedAt())
+                .sectionUpdatedAt(section.getUpdatedAt())
+                .nodeGroupId(nodeGroup.getId())
+                .nodeGroupTitle(nodeGroup.getTitle())
+                .nodeGroupOrder(nodeGroup.getOrder().intValue())
+                .nodeGroupCreatedAt(nodeGroup.getCreatedAt())
+                .nodeGroupUpdatedAt(nodeGroup.getUpdatedAt())
+                .build();
+        }
     }
 }

--- a/src/main/java/com/handongapp/cms/repository/NodeGroupRepository.java
+++ b/src/main/java/com/handongapp/cms/repository/NodeGroupRepository.java
@@ -13,9 +13,9 @@ public interface NodeGroupRepository extends JpaRepository<TbNodeGroup, String> 
     Optional<TbNodeGroup> findByIdAndDeleted(String id, String deleted);
     List<TbNodeGroup> findBySectionIdAndDeletedOrderByOrderAsc(String sectionId, String deleted);
 
-    @Query(value = "SELECT ng FROM TbNodeGroup ng WHERE ng.sectionId = :sectionId AND ng.deleted = 'N' AND ng.order > :currentOrder ORDER BY ng.order ASC LIMIT 1",nativeQuery = true)
+    @Query("SELECT ng FROM TbNodeGroup ng WHERE ng.sectionId = :sectionId AND ng.deleted = 'N' AND ng.order > :currentOrder ORDER BY ng.order ASC LIMIT 1")
     Optional<TbNodeGroup> findNextInSameSection(@Param("sectionId") String sectionId, @Param("currentOrder") int currentOrder);
 
-    @Query(value = "SELECT ng FROM TbNodeGroup ng WHERE ng.sectionId = :sectionId AND ng.deleted = 'N' ORDER BY ng.order ASC LIMIT 1",nativeQuery = true)
+    @Query("SELECT ng FROM TbNodeGroup ng WHERE ng.sectionId = :sectionId AND ng.deleted = 'N' ORDER BY ng.order ASC LIMIT 1")
     Optional<TbNodeGroup> findFirstInNextSection(@Param("sectionId") String sectionId);
 }

--- a/src/main/java/com/handongapp/cms/repository/NodeGroupRepository.java
+++ b/src/main/java/com/handongapp/cms/repository/NodeGroupRepository.java
@@ -13,9 +13,9 @@ public interface NodeGroupRepository extends JpaRepository<TbNodeGroup, String> 
     Optional<TbNodeGroup> findByIdAndDeleted(String id, String deleted);
     List<TbNodeGroup> findBySectionIdAndDeletedOrderByOrderAsc(String sectionId, String deleted);
 
-    @Query("SELECT ng FROM TbNodeGroup ng WHERE ng.sectionId = :sectionId AND ng.deleted = 'N' AND ng.order > :currentOrder ORDER BY ng.order ASC LIMIT 1")
+    @Query(value = "SELECT ng FROM TbNodeGroup ng WHERE ng.sectionId = :sectionId AND ng.deleted = 'N' AND ng.order > :currentOrder ORDER BY ng.order ASC LIMIT 1",nativeQuery = true)
     Optional<TbNodeGroup> findNextInSameSection(@Param("sectionId") String sectionId, @Param("currentOrder") int currentOrder);
 
-    @Query("SELECT ng FROM TbNodeGroup ng WHERE ng.sectionId = :sectionId AND ng.deleted = 'N' ORDER BY ng.order ASC LIMIT 1")
+    @Query(value = "SELECT ng FROM TbNodeGroup ng WHERE ng.sectionId = :sectionId AND ng.deleted = 'N' ORDER BY ng.order ASC LIMIT 1",nativeQuery = true)
     Optional<TbNodeGroup> findFirstInNextSection(@Param("sectionId") String sectionId);
 }

--- a/src/main/java/com/handongapp/cms/repository/NodeGroupRepository.java
+++ b/src/main/java/com/handongapp/cms/repository/NodeGroupRepository.java
@@ -2,6 +2,8 @@ package com.handongapp.cms.repository;
 
 import com.handongapp.cms.domain.TbNodeGroup;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import java.util.List;
 import java.util.Optional;
@@ -10,4 +12,10 @@ import java.util.Optional;
 public interface NodeGroupRepository extends JpaRepository<TbNodeGroup, String> {
     Optional<TbNodeGroup> findByIdAndDeleted(String id, String deleted);
     List<TbNodeGroup> findBySectionIdAndDeletedOrderByOrderAsc(String sectionId, String deleted);
+
+    @Query("SELECT ng FROM TbNodeGroup ng WHERE ng.sectionId = :sectionId AND ng.deleted = 'N' AND ng.order > :currentOrder ORDER BY ng.order ASC LIMIT 1")
+    Optional<TbNodeGroup> findNextInSameSection(@Param("sectionId") String sectionId, @Param("currentOrder") int currentOrder);
+
+    @Query("SELECT ng FROM TbNodeGroup ng WHERE ng.sectionId = :sectionId AND ng.deleted = 'N' ORDER BY ng.order ASC LIMIT 1")
+    Optional<TbNodeGroup> findFirstInNextSection(@Param("sectionId") String sectionId);
 }

--- a/src/main/java/com/handongapp/cms/repository/SectionRepository.java
+++ b/src/main/java/com/handongapp/cms/repository/SectionRepository.java
@@ -2,6 +2,8 @@ package com.handongapp.cms.repository;
 
 import com.handongapp.cms.domain.TbSection;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import java.util.List;
 import java.util.Optional;
@@ -10,4 +12,7 @@ import java.util.Optional;
 public interface SectionRepository extends JpaRepository<TbSection, String> {
     Optional<TbSection> findByIdAndDeleted(String id, String deleted);
     List<TbSection> findByCourseIdAndDeletedOrderByOrderAsc(String courseId, String deleted);
+
+    @Query("SELECT s FROM TbSection s WHERE s.courseId = :courseId AND s.deleted = 'N' AND s.order > :currentOrder ORDER BY s.order ASC LIMIT 1")
+    Optional<TbSection> findNextInCourse(@Param("courseId") String courseId, @Param("currentOrder") int currentOrder);
 }

--- a/src/main/java/com/handongapp/cms/repository/SectionRepository.java
+++ b/src/main/java/com/handongapp/cms/repository/SectionRepository.java
@@ -13,6 +13,6 @@ public interface SectionRepository extends JpaRepository<TbSection, String> {
     Optional<TbSection> findByIdAndDeleted(String id, String deleted);
     List<TbSection> findByCourseIdAndDeletedOrderByOrderAsc(String courseId, String deleted);
 
-    @Query(value = "SELECT s FROM TbSection s WHERE s.courseId = :courseId AND s.deleted = 'N' AND s.order > :currentOrder ORDER BY s.order ASC LIMIT 1",nativeQuery = true)
+    @Query("SELECT s FROM TbSection s WHERE s.courseId = :courseId AND s.deleted = 'N' AND s.order > :currentOrder ORDER BY s.order ASC LIMIT 1")
     Optional<TbSection> findNextInCourse(@Param("courseId") String courseId, @Param("currentOrder") int currentOrder);
 }

--- a/src/main/java/com/handongapp/cms/repository/SectionRepository.java
+++ b/src/main/java/com/handongapp/cms/repository/SectionRepository.java
@@ -13,6 +13,6 @@ public interface SectionRepository extends JpaRepository<TbSection, String> {
     Optional<TbSection> findByIdAndDeleted(String id, String deleted);
     List<TbSection> findByCourseIdAndDeletedOrderByOrderAsc(String courseId, String deleted);
 
-    @Query("SELECT s FROM TbSection s WHERE s.courseId = :courseId AND s.deleted = 'N' AND s.order > :currentOrder ORDER BY s.order ASC LIMIT 1")
+    @Query(value = "SELECT s FROM TbSection s WHERE s.courseId = :courseId AND s.deleted = 'N' AND s.order > :currentOrder ORDER BY s.order ASC LIMIT 1",nativeQuery = true)
     Optional<TbSection> findNextInCourse(@Param("courseId") String courseId, @Param("currentOrder") int currentOrder);
 }

--- a/src/main/java/com/handongapp/cms/service/NodeGroupService.java
+++ b/src/main/java/com/handongapp/cms/service/NodeGroupService.java
@@ -1,7 +1,9 @@
 package com.handongapp.cms.service;
 
 import com.handongapp.cms.dto.v1.NodeGroupDto;
+
 import java.util.List;
+import java.util.Optional;
 
 public interface NodeGroupService {
     NodeGroupDto.Response create(NodeGroupDto.CreateRequest req);
@@ -9,5 +11,8 @@ public interface NodeGroupService {
     List<NodeGroupDto.Response> listBySection(String sectionId);
     NodeGroupDto.Response update(String id, NodeGroupDto.UpdateRequest req);
     void deleteSoft(String id);
+
     String fetchAllInfo(String nodeGroupId);
+
+    Optional<NodeGroupDto.NextNodeGroupResponseDto> getNextNodeGroupInSectionOrCourse(String currentNodeGroupId);
 }

--- a/src/main/java/com/handongapp/cms/service/impl/NodeGroupServiceImpl.java
+++ b/src/main/java/com/handongapp/cms/service/impl/NodeGroupServiceImpl.java
@@ -2,8 +2,10 @@ package com.handongapp.cms.service.impl;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.handongapp.cms.domain.TbNodeGroup;
+import com.handongapp.cms.domain.TbSection;
 import com.handongapp.cms.dto.v1.NodeGroupDto;
 import com.handongapp.cms.repository.NodeGroupRepository;
+import com.handongapp.cms.repository.SectionRepository;
 import com.handongapp.cms.service.NodeGroupService;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +13,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import com.handongapp.cms.mapper.NodeGroupMapper;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -20,10 +23,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 public class NodeGroupServiceImpl implements NodeGroupService {
 
     private final NodeGroupMapper nodeGroupMapper;
-
     private final ObjectMapper objectMapper;
 
     private final NodeGroupRepository nodeGroupRepository;
+    private final SectionRepository sectionRepository; 
 
     @Override
     @Transactional
@@ -83,4 +86,39 @@ public class NodeGroupServiceImpl implements NodeGroupService {
             throw new IllegalStateException("NodeGroup JSON 파싱/직렬화에 실패했습니다.", e);
         }
     }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<NodeGroupDto.NextNodeGroupResponseDto> getNextNodeGroupInSectionOrCourse(String currentNodeGroupId) {
+        TbNodeGroup currentNodeGroup = nodeGroupRepository.findByIdAndDeleted(currentNodeGroupId, "N")
+                .orElseThrow(() -> new EntityNotFoundException("NodeGroup not found with id: " + currentNodeGroupId));
+
+        // 1. Try to find next node group in the same section
+        Optional<TbNodeGroup> nextNodeGroupOpt = nodeGroupRepository.findNextInSameSection(currentNodeGroup.getSectionId(), currentNodeGroup.getOrder().intValue());
+
+        if (nextNodeGroupOpt.isPresent()) {
+            TbNodeGroup nextNodeGroup = nextNodeGroupOpt.get();
+            TbSection currentSection = sectionRepository.findByIdAndDeleted(currentNodeGroup.getSectionId(), "N")
+                    .orElseThrow(() -> new EntityNotFoundException("Section not found for current node group's section: " + currentNodeGroup.getSectionId()));
+            return Optional.of(NodeGroupDto.NextNodeGroupResponseDto.buildResponseDto(currentSection, nextNodeGroup));
+        }
+
+        // 2. If not found, try to find the first node group in the next section of the same course
+        TbSection currentSectionForNextSearch = sectionRepository.findByIdAndDeleted(currentNodeGroup.getSectionId(), "N")
+                .orElseThrow(() -> new EntityNotFoundException("Section not found for current node group's section: " + currentNodeGroup.getSectionId()));
+
+        Optional<TbSection> nextSectionOpt = sectionRepository.findNextInCourse(currentSectionForNextSearch.getCourseId(), currentSectionForNextSearch.getOrder().intValue());
+
+        if (nextSectionOpt.isPresent()) {
+            TbSection nextSection = nextSectionOpt.get();
+            Optional<TbNodeGroup> firstNodeGroupInNextSectionOpt = nodeGroupRepository.findFirstInNextSection(nextSection.getId());
+
+            if (firstNodeGroupInNextSectionOpt.isPresent()) {
+                return Optional.of(NodeGroupDto.NextNodeGroupResponseDto.buildResponseDto(nextSection, firstNodeGroupInNextSectionOpt.get()));
+            }
+        }
+        return Optional.empty();
+    }
+
+
 }


### PR DESCRIPTION

## 📌 관련 이슈
<!-- 닫을 이슈 번호를 명시해주세요 
- Resolves #111 

___ 

## ✨ 작업 내용
/v1/node-group/next endpoint을 구현함

___ 

## 🔎 세부 설명
새로운 Dto를 NodeGroupDto inner class로 만들고 JPA를 사용하여 구현함 (쿼리 자체는 이름만으로는 생성이 어려워 어노테이션을 사용함)
동작은 다음과 같다
1. 같은 섹션 내에 다음 노드그룹이 있다면 해당 정보를 섹션과 함께 리턴한다
2. 없다면 다음 섹션에 다음 노드 그룹이 있는지 검사하고 있다면 역시 섹션 정보와 함께 리턴한다.
3. 최종적으로 없다면 빈 json을 리턴한다.

___ 

## 🧪 테스트
- [x] bruno으로 api 테스트



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 현재 노드 그룹 ID를 기반으로 같은 섹션 내 다음 노드 그룹 또는 다음 섹션의 첫 번째 노드 그룹 정보를 조회할 수 있는 GET 엔드포인트가 추가되었습니다.
  - 노드 그룹 및 섹션의 상세 정보를 포함한 응답을 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->