### PR TITLE
[BE/FEAT] 노드 일반 파일, 이미지 READ

### DIFF
--- a/.bruno/v1/folder.bru
+++ b/.bruno/v1/folder.bru
@@ -1,4 +1,8 @@
 meta {
-    name: v1
-    seq: 2
+  name: v1
+  seq: 2
+}
+
+auth {
+  mode: inherit
 }

--- a/.bruno/v1/node-group/nodeGroupList.bru
+++ b/.bruno/v1/node-group/nodeGroupList.bru
@@ -11,5 +11,5 @@ get {
 }
 
 vars:pre-request {
-  nodeGroupId: nodg0000000000000000000000000002
+  nodeGroupId: 088c56343a6f4d14b9920e7964c8869f
 }

--- a/src/main/java/com/handongapp/cms/service/impl/NodeGroupServiceImpl.java
+++ b/src/main/java/com/handongapp/cms/service/impl/NodeGroupServiceImpl.java
@@ -83,18 +83,19 @@ public class NodeGroupServiceImpl implements NodeGroupService {
             JsonNode nodes = root.get("nodes");
             if (nodes != null && nodes.isArray()) {
                 for (JsonNode node : nodes) {
-                    String type = node.get("type").asText();
+                    JsonNode typeNode = node.get("type");
+                    if (typeNode == null) continue;
+                    String type = typeNode.asText();
                     if ("IMAGE".equals(type) || "FILE".equals(type)) {
-                        JsonNode fileNode = node.get("data").get("file");
+                        JsonNode dataNode = node.get("data");
+                        if (dataNode == null) continue;
+                        JsonNode fileNode = dataNode.get("file");
                         if (fileNode != null){
                             if (fileNode.has("fileKey")
                                     && fileNode.has("status")
                                     && "UPLOADED".equals(fileNode.get("status").asText())) {
-
                                 String fileKey = fileNode.get("fileKey").asText();
-
                                 String presignedUrl = presignedUrlService.generateDownloadUrl(fileKey).toString();
-
                                 ((ObjectNode) fileNode).put("presignedUrl", presignedUrl);
                             }
                             ((ObjectNode) fileNode).remove("fileKey");

--- a/src/main/java/com/handongapp/cms/service/impl/NodeGroupServiceImpl.java
+++ b/src/main/java/com/handongapp/cms/service/impl/NodeGroupServiceImpl.java
@@ -86,19 +86,18 @@ public class NodeGroupServiceImpl implements NodeGroupService {
                     String type = node.get("type").asText();
                     if ("IMAGE".equals(type) || "FILE".equals(type)) {
                         JsonNode fileNode = node.get("data").get("file");
-                        if (fileNode != null
-                                && fileNode.has("fileKey")
-                                && fileNode.has("status")
-                                && "UPLOADED".equals(fileNode.get("status").asText())) {
+                        if (fileNode != null){
+                            if (fileNode.has("fileKey")
+                                    && fileNode.has("status")
+                                    && "UPLOADED".equals(fileNode.get("status").asText())) {
 
-                            String fileKey = fileNode.get("fileKey").asText();
+                                String fileKey = fileNode.get("fileKey").asText();
 
-                            // presigned URL 생성
-                            String presignedUrl = presignedUrlService.generateDownloadUrl(fileKey).toString();
+                                String presignedUrl = presignedUrlService.generateDownloadUrl(fileKey).toString();
 
-                            // "fileKey" 제거하고 "presignedUrl" 추가
+                                ((ObjectNode) fileNode).put("presignedUrl", presignedUrl);
+                            }
                             ((ObjectNode) fileNode).remove("fileKey");
-                            ((ObjectNode) fileNode).put("presignedUrl", presignedUrl);
                         }
                     }
                 }

--- a/src/main/java/com/handongapp/cms/service/impl/NodeGroupServiceImpl.java
+++ b/src/main/java/com/handongapp/cms/service/impl/NodeGroupServiceImpl.java
@@ -1,6 +1,7 @@
 package com.handongapp.cms.service.impl;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.handongapp.cms.domain.TbNodeGroup;
 import com.handongapp.cms.dto.v1.NodeGroupDto;
 import com.handongapp.cms.repository.NodeGroupRepository;
@@ -20,10 +21,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 public class NodeGroupServiceImpl implements NodeGroupService {
 
     private final NodeGroupMapper nodeGroupMapper;
-
     private final ObjectMapper objectMapper;
-
     private final NodeGroupRepository nodeGroupRepository;
+    private final PresignedUrlServiceImpl presignedUrlService;
 
     @Override
     @Transactional
@@ -75,10 +75,35 @@ public class NodeGroupServiceImpl implements NodeGroupService {
         }
         nodeGroupRepository.findByIdAndDeleted(nodeGroupId, "N")
                 .orElseThrow(() -> new EntityNotFoundException("NodeGroup not found with id: " + nodeGroupId + " or it has been deleted."));
+
         String rawJson = nodeGroupMapper.fetchAllInfoByNodeGroupId(nodeGroupId);
+
         try {
-            JsonNode node = objectMapper.readTree(rawJson);
-            return objectMapper.writeValueAsString(node);
+            JsonNode root = objectMapper.readTree(rawJson);
+            JsonNode nodes = root.get("nodes");
+            if (nodes != null && nodes.isArray()) {
+                for (JsonNode node : nodes) {
+                    String type = node.get("type").asText();
+                    if ("IMAGE".equals(type) || "FILE".equals(type)) {
+                        JsonNode fileNode = node.get("data").get("file");
+                        if (fileNode != null
+                                && fileNode.has("fileKey")
+                                && fileNode.has("status")
+                                && "UPLOADED".equals(fileNode.get("status").asText())) {
+
+                            String fileKey = fileNode.get("fileKey").asText();
+
+                            // presigned URL 생성
+                            String presignedUrl = presignedUrlService.generateDownloadUrl(fileKey).toString();
+
+                            // "fileKey" 제거하고 "presignedUrl" 추가
+                            ((ObjectNode) fileNode).remove("fileKey");
+                            ((ObjectNode) fileNode).put("presignedUrl", presignedUrl);
+                        }
+                    }
+                }
+            }
+            return objectMapper.writeValueAsString(root);
         } catch (Exception e) {
             throw new IllegalStateException("NodeGroup JSON 파싱/직렬화에 실패했습니다.", e);
         }


### PR DESCRIPTION
## 📌 관련 이슈
- Resolves #109 
___

## ✨ 작업 내용
- IMAGE 및 FILE 타입 노드의 JSON 응답에서 `fileKey`를 제거하고, 대신 S3 presigned URL을 `presignedUrl`로 추가했습니다.
- presigned URL은 노드의 파일이 업로드 완료 상태(UPLOADED)인 경우에만 발급됩니다.
- 이미지/파일 노드 응답에는 `originalFileName`, `contentType`도 함께 제공됩니다.

___

## 🔎 세부 설명
- 기존의 `fileKey`는 보안상 노출을 방지하기 위해 제거하였습니다.
- `presignedUrl`은 실제 S3 다운로드 링크를 안전하게 제공하도록 PresignedUrlService에서 생성됩니다.
- 노드의 `data.file.status`가 `UPLOADED`인 경우에만 presigned URL을 발급하여, 업로드 중/실패 상태에서는 URL이 제공되지 않습니다.
- MyBatis XML 쿼리 및 NodeGroupServiceImpl에서 JSON을 후처리하도록 구현했습니다.

___

## 🧪 테스트
- [x] Bruno로 이미지/파일 노드의 presigned URL 다운로드 정상 작동 확인
- [x] 업로드 중/실패 상태에서는 presigned URL이 응답되지 않는지 확인
- [x] QUIZ, TEXT 등 파일 없는 노드에는 presigned URL이 응답에 포함되지 않는지 확인

___

## ➕ 기타
- 향후 VIDEO 타입 노드에 대해서도 다운로드 presigned URL 발급이 필요할 수 있습니다. 관련 로직은 추후 확장 예정입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 이미지 및 파일 노드의 파일 객체에 업로드된 경우 presigned 다운로드 URL이 추가되어 반환됩니다.

- **버그 수정**
  - 파일 객체에서 fileKey 필드가 제거되어 보안이 향상되었습니다.

- **기타**
  - 인증 모드 설정이 명시적으로 추가되었습니다.
  - 일부 내부 변수 값이 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->