### PR TITLE
[BE/hotfix] add no-args constructor to enable Jackson deserializati…

### DIFF
--- a/src/main/java/com/handongapp/cms/auth/dto/GoogleUserInfoResponse.java
+++ b/src/main/java/com/handongapp/cms/auth/dto/GoogleUserInfoResponse.java
@@ -1,11 +1,15 @@
 package com.handongapp.cms.auth.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 @AllArgsConstructor
+@NoArgsConstructor
 @Getter
 @Setter
 public class GoogleUserInfoResponse {
@@ -15,5 +19,4 @@ public class GoogleUserInfoResponse {
     @JsonProperty("given_name")  private String givenName;
     @JsonProperty("family_name")  private String familyName;
     private String picture;
-    private String locale;
 }


### PR DESCRIPTION
<!-- CMS PR 가이드 -->
<!-- 가이드이므로 필요없는 내용은 지워주셔도 됩니다! -->

## ✅ PR 체크리스트

- [x] 로컬 환경에서 작동 확인 (애러 없는지)
- [x] 제목에 작업 파트 추가 ([FE] 또는 [BE] Prefix 추가)

## 📌 관련 이슈
<!-- 닫을 이슈 번호를 명시해주세요 -->
<!-- e.g., Resolves #123 -->
<!-- 해당 없음 -->

___ 

## ✨ 작업 내용

- GoogleUserInfoResponse 클래스에 기본 생성자(@NoArgsConstructor) 추가

___ 

## 🔎 세부 설명

- Jackson에서 역직렬화를 위해 기본 생성자가 필요하지만, 해당 클래스에 `@AllArgsConstructor`만 있어 오류가 발생함
- `@NoArgsConstructor`를 추가하여 `WebClient`로 Google API 응답을 처리할 수 있도록 수정
- 오류 메시지 예: `InvalidDefinitionException: no Creators, like default constructor, exist`

___ 

## 🧪 테스트

- [x] 유효한 Google access token으로 WebClient 호출 성공 확인
- [x] 응답 매핑 오류 없이 GoogleUserInfoResponse 정상 생성 확인
- [x] 기존 API 흐름 정상 동작 확인

___ 

## ➕ 기타

- `@JsonIgnoreProperties(ignoreUnknown = true)`를 함께 적용하여, Google 응답에 정의되지 않은 필드(name, hd 등)가 있어도 예외 발생하지 않도록 처리함
