### PR TITLE
🚑️ Hotfix: delete attachment_url column from tb_node table

### DIFF
--- a/src/main/java/com/handongapp/cms/domain/TbNode.java
+++ b/src/main/java/com/handongapp/cms/domain/TbNode.java
@@ -37,12 +37,6 @@ public class TbNode extends AuditingFields {
     @Enumerated(EnumType.STRING)
     private NodeType type;
 
-//    /** Optional attachment */
-//    @Lob
-//    @Column(name = "attachment_url")
-//    private String attachmentUrl;
-
-
     /** Whether comments are allowed for this node */
     @Column(name = "is_comment_permitted")
     private Boolean commentPermitted = Boolean.FALSE;

--- a/src/main/resources/mapper/ClubMapper.xml
+++ b/src/main/resources/mapper/ClubMapper.xml
@@ -96,7 +96,6 @@
                                                     'type',n.type,
                                                     'data',n.data,
                                                     'order', n.order,
-                                                    'attachmentUrl', n.attachment_url,
                                                     'isCommentPermitted', n.is_comment_permitted = b'1'
                                                 )
                                             ) FROM tb_node n

--- a/src/main/resources/mapper/CourseMapper.xml
+++ b/src/main/resources/mapper/CourseMapper.xml
@@ -32,7 +32,6 @@
                                                     'type',n.type,
                                                     'data',n.data,
                                                     'order', n.order,
-                                                    'attachmentUrl', n.attachment_url,
                                                     'isCommentPermitted', n.is_comment_permitted = b'1'
                                                 )
                                             ) FROM tb_node n

--- a/src/main/resources/mapper/NodeGroupMapper.xml
+++ b/src/main/resources/mapper/NodeGroupMapper.xml
@@ -20,7 +20,6 @@
                         'commentPermitted', n.is_comment_permitted = b'1',
                         'data', n.data,
                         'order', n.order,
-                        'attachmentUrl', n.attachment_url,
                         'createdAt', n.created_at,
                         'updatedAt', n.updated_at,
                         'comments', ( -- Comments for this specific node 'n'

--- a/src/main/resources/mapper/ProgramMapper.xml
+++ b/src/main/resources/mapper/ProgramMapper.xml
@@ -43,7 +43,6 @@
                                                                 'type',n.type,
                                                                 'data',n.data,
                                                                 'order', n.order,
-                                                                'attachmentUrl', n.attachment_url,
                                                                 'isCommentPermitted', n.is_comment_permitted = b'1'
                                                             )
                                                         ) FROM tb_node n
@@ -115,7 +114,6 @@
                                                                         'type',n.type,
                                                                         'data',n.data,
                                                                         'order', n.order,
-                                                                        'attachmentUrl', n.attachment_url,
                                                                         'isCommentPermitted', n.is_comment_permitted = b'1'
                                                                     )
                                                                 ) FROM tb_node n


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 닫을 이슈 번호를 명시해주세요 
- Resolves #123  -->

___ 

## ✨ 작업 내용
attachment_url column 내용 및 관련 코드 삭제 처리

## 🧪 테스트
- [x] bruno로 기존 테스트 진행


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- 노드 관련 정보의 JSON 데이터에서 더 이상 'attachmentUrl' 필드가 제공되지 않습니다.  
- **Refactor**
	- 불필요한 주석 및 사용되지 않는 필드 관련 코드를 정리하였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->