### PR TITLE
🐛 FE/Bug : Fix duplicate Google OAuth request on login

### DIFF
--- a/src/main/front/src/pages/GoogleCallback.tsx
+++ b/src/main/front/src/pages/GoogleCallback.tsx
@@ -24,7 +24,7 @@ const GoogleOAuthCallback: React.FC = () => {
   const [output, setOutput] = useState("처리 중...");
   const [loginCheckResult, setLoginCheckResult] = useState("");
   const hasFetched = useRef(false); 
-  
+
   const {
     jwtToken,
     refreshToken,
@@ -93,6 +93,7 @@ const GoogleOAuthCallback: React.FC = () => {
     } catch (err: any) {
       console.error("🚨 로그인 처리 중 오류:", err.message || err);
       setOutput("로그인 실패: " + (err.message || "알 수 없는 오류"));
+      hasFetched.current = false; // 에러 시 재시도 가능하도록 플래그 재설정
     }
   };
     fetchTokens(code);


### PR DESCRIPTION
Prevented multiple requests with the same authorization code by adding a useRef flag inside GoogleOAuthCallback.

<!-- CMS PR 가이드 -->

## ✅ PR 체크리스트

- [x] 로컬 환경에서 작동 확인 (에러 없는지)
- [x] 제목에 작업 파트 추가 ([FE] 또는 [BE] Prefix 추가)

## 📌 관련 이슈
- Resolves #130

___ 

## ✨ 작업 내용
- Google OAuth 로그인 시 authorization code가 중복 전송되는 문제를 해결

___ 

## 🔎 세부 설명
- React의 `useEffect` 훅이 두 번 실행되면서 같은 authorization code가 두 번 백엔드에 요청되는 문제가 발생했음
- 이를 방지하기 위해 `useRef` 플래그(`hasFetched`)를 도입하여 코드 요청을 한 번만 수행하도록 개선
- 중복 요청 시도 시에는 로깅만 하고 무시되도록 처리

___ 

## 🧪 테스트
- [x] 실제 Google OAuth 로그인 테스트
- [x] `useEffect` 중복 실행 확인용 console 로그 확인
- [x] 백엔드로의 요청이 1회만 발생하는지 로그로 확인

___ 

## ➕ 기타
- 개발 환경(React 18)의 Strict Mode에서 `useEffect`가 두 번 실행되는 동작을 고려한 처리
- production 환경에서는 재현되지 않지만, 개발 중에도 오류가 발생하지 않도록 보완함

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **버그 수정**
  - Google OAuth 인증 콜백 처리 시 중복 요청이 발생하지 않도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
