### PR TITLE
Feat/127 comment crud api

### DIFF
--- a/.bruno/v1/comment/Delete Comment.bru
+++ b/.bruno/v1/comment/Delete Comment.bru
@@ -11,7 +11,5 @@ delete {
 }
 
 vars:pre-request {
-  targetId: b8856eed3e2c49a089576a3fd42be3f9
   commentIdToDelete: b4e094f8e5434c42bbb6565bdc05fcf0
-  userId: asdf
 }

--- a/.bruno/v1/comment/Delete Comment.bru
+++ b/.bruno/v1/comment/Delete Comment.bru
@@ -5,17 +5,13 @@ meta {
 }
 
 delete {
-  url: {{BASE_URL_LOCAL}}/api/v1/targets/{{targetId}}/comments/{{commentIdToUpdate}}?userId={{userId}}
+  url: {{BASE_URL_LOCAL}}/api/v1/comments/{{commentIdToDelete}}
   body: json
   auth: inherit
 }
 
-params:query {
-  userId: {{userId}}
-}
-
 vars:pre-request {
   targetId: b8856eed3e2c49a089576a3fd42be3f9
-  commentIdToUpdate: b4e094f8e5434c42bbb6565bdc05fcf0
+  commentIdToDelete: b4e094f8e5434c42bbb6565bdc05fcf0
   userId: asdf
 }

--- a/.bruno/v1/comment/create-comment.bru
+++ b/.bruno/v1/comment/create-comment.bru
@@ -5,22 +5,15 @@ meta {
 }
 
 post {
-  url: {{BASE_URL_LOCAL}}/api/v1/targets/{{targetId}}/comments?userId=asdf
+  url: {{BASE_URL_LOCAL}}/api/v1/comments
   body: json
   auth: inherit
-}
-
-params:query {
-  userId: asdf
 }
 
 body:json {
   {
     "content": "첫 번째 테스트 댓글입니다!",
-    "categoryId": "sampleCategory123"
+    "categoryId": "cate0000000000000000000000000001",
+    "targetId": "1d69af51a2c84e1d86f015b33fbca106"
   }
-}
-
-vars:pre-request {
-  targetId: b8856eed3e2c49a089576a3fd42be3f9
 }

--- a/.bruno/v1/comment/list-comments.bru
+++ b/.bruno/v1/comment/list-comments.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: {{BASE_URL_LOCAL}}/api/v1/targets/{{targetId}}/comments
+  url: {{BASE_URL_LOCAL}}/api/v1/comments/search?
   body: none
   auth: inherit
 }

--- a/.bruno/v1/comment/update-comment.bru
+++ b/.bruno/v1/comment/update-comment.bru
@@ -5,23 +5,20 @@ meta {
 }
 
 patch {
-  url: {{BASE_URL_LOCAL}}/api/v1/targets/{{targetId}}/comments/{{commentIdToUpdate}}?userId=asdf
+  url: {{BASE_URL_LOCAL}}/api/v1/comments/{{commentIdToUpdate}}
   body: json
   auth: inherit
 }
 
-params:query {
-  userId: asdf
-}
-
 body:json {
   {
-    "content": "댓글 내용이 수정되었습니다.",
-    "categoryId": "updatedCategory456"
+    "content": "댓글 내용이 수정되었습니다."
+    
   }
+  
+  //댓글은 작성자 본인만 수정할 수 있습니다.
 }
 
 vars:pre-request {
-  targetId: b8856eed3e2c49a089576a3fd42be3f9
   commentIdToUpdate: 3451f4b435c642bfa56b13a87f4e529b
 }

--- a/src/main/java/com/handongapp/cms/controller/v1/CommentController.java
+++ b/src/main/java/com/handongapp/cms/controller/v1/CommentController.java
@@ -23,8 +23,7 @@ public class CommentController {
     public ResponseEntity<CommentDto.Response> create(
             Authentication authentication,
             @RequestBody @Valid CommentDto.CreateRequest req) {
-        PrincipalDetails principalDetails = (PrincipalDetails) authentication.getPrincipal();
-        String userId = principalDetails.getUsername();
+        String userId = extractUserId(authentication);
         CommentDto.Response response = commentService.create(userId, req);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
@@ -34,8 +33,7 @@ public class CommentController {
             Authentication authentication,
             @PathVariable String commentId,
             @RequestBody @Valid CommentDto.UpdateRequest req) {
-        PrincipalDetails principalDetails = (PrincipalDetails) authentication.getPrincipal();
-        String userId = principalDetails.getUsername();
+        String userId = extractUserId(authentication);
         CommentDto.Response response = commentService.update(commentId, userId, req);
         return ResponseEntity.ok(response);
     }
@@ -44,8 +42,7 @@ public class CommentController {
     public ResponseEntity<Void> delete(
             Authentication authentication,
             @PathVariable String commentId) {
-        PrincipalDetails principalDetails = (PrincipalDetails) authentication.getPrincipal();
-        String userId = principalDetails.getUsername();
+        String userId = extractUserId(authentication);
         commentService.deleteSoft(commentId, userId);
         return ResponseEntity.noContent().build();
     }
@@ -58,11 +55,14 @@ public class CommentController {
             @RequestParam(required = false) String userId,
             @RequestParam(required = false) String username
     ) {
-
-
         List<CommentDto.Response> responses = commentService.searchComments(
                 courseId, courseSlug, courseName, userId, username
         );
         return ResponseEntity.ok(responses);
+    }
+
+    private String extractUserId(Authentication authentication) {
+        PrincipalDetails principalDetails = (PrincipalDetails) authentication.getPrincipal();
+        return principalDetails.getUsername();
     }
 }

--- a/src/main/java/com/handongapp/cms/controller/v1/CommentController.java
+++ b/src/main/java/com/handongapp/cms/controller/v1/CommentController.java
@@ -52,11 +52,12 @@ public class CommentController {
             @RequestParam(required = false) String courseId,
             @RequestParam(required = false) String courseSlug,
             @RequestParam(required = false) String courseName,
+            @RequestParam(required = false) String nodeGroupId,
             @RequestParam(required = false) String userId,
             @RequestParam(required = false) String username
     ) {
         List<CommentDto.Response> responses = commentService.searchComments(
-                courseId, courseSlug, courseName, userId, username
+                courseId, courseSlug, courseName, nodeGroupId, userId, username
         );
         return ResponseEntity.ok(responses);
     }

--- a/src/main/java/com/handongapp/cms/controller/v1/CommentController.java
+++ b/src/main/java/com/handongapp/cms/controller/v1/CommentController.java
@@ -1,6 +1,7 @@
 package com.handongapp.cms.controller.v1;
 
 import com.handongapp.cms.dto.v1.CommentDto;
+import com.handongapp.cms.exception.auth.NoAuthenticatedException;
 import com.handongapp.cms.security.PrincipalDetails;
 import com.handongapp.cms.service.CommentService;
 import jakarta.validation.Valid;
@@ -64,7 +65,7 @@ public class CommentController {
 
     private String extractUserId(Authentication authentication) {
         if (authentication == null || authentication.getPrincipal() == null) {
-            throw new IllegalStateException("인증 정보가 없습니다");
+            throw new NoAuthenticatedException("인증 정보가 없습니다");
         }
         if (!(authentication.getPrincipal() instanceof PrincipalDetails)) {
             throw new IllegalStateException("잘못된 인증 타입입니다");

--- a/src/main/java/com/handongapp/cms/controller/v1/CommentController.java
+++ b/src/main/java/com/handongapp/cms/controller/v1/CommentController.java
@@ -63,7 +63,14 @@ public class CommentController {
     }
 
     private String extractUserId(Authentication authentication) {
+        if (authentication == null || authentication.getPrincipal() == null) {
+            throw new IllegalStateException("인증 정보가 없습니다");
+        }
+        if (!(authentication.getPrincipal() instanceof PrincipalDetails)) {
+            throw new IllegalStateException("잘못된 인증 타입입니다");
+        }
         PrincipalDetails principalDetails = (PrincipalDetails) authentication.getPrincipal();
+        
         return principalDetails.getUsername();
     }
 }

--- a/src/main/java/com/handongapp/cms/controller/v1/CommentController.java
+++ b/src/main/java/com/handongapp/cms/controller/v1/CommentController.java
@@ -1,17 +1,19 @@
 package com.handongapp.cms.controller.v1;
 
 import com.handongapp.cms.dto.v1.CommentDto;
+import com.handongapp.cms.security.PrincipalDetails;
 import com.handongapp.cms.service.CommentService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/v1/targets/{targetId}/comments")
+@RequestMapping("/api/v1/comments")
 @RequiredArgsConstructor
 public class CommentController {
 
@@ -19,36 +21,48 @@ public class CommentController {
 
     @PostMapping
     public ResponseEntity<CommentDto.Response> create(
-            @PathVariable String targetId,
-            @RequestParam String userId, // TODO: JWT 인증 도입 시 Principal 객체 등으로 대체
+            Authentication authentication,
             @RequestBody @Valid CommentDto.CreateRequest req) {
-        CommentDto.Response response = commentService.create(targetId, userId, req);
+        PrincipalDetails principalDetails = (PrincipalDetails) authentication.getPrincipal();
+        String userId = principalDetails.getUsername();
+        CommentDto.Response response = commentService.create(userId, req);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
-    }
-
-    @GetMapping
-    public ResponseEntity<List<CommentDto.Response>> listByTarget(
-            @PathVariable String targetId) {
-        List<CommentDto.Response> responses = commentService.listByTarget(targetId);
-        return ResponseEntity.ok(responses);
     }
 
     @PatchMapping("/{commentId}")
     public ResponseEntity<CommentDto.Response> update(
-            @PathVariable String targetId, // 경로 일관성 유지, 실제 로직에서는 commentId 사용
+            Authentication authentication,
             @PathVariable String commentId,
-            @RequestParam String userId, // TODO: JWT 인증 도입 시 Principal 객체 등으로 대체
             @RequestBody @Valid CommentDto.UpdateRequest req) {
+        PrincipalDetails principalDetails = (PrincipalDetails) authentication.getPrincipal();
+        String userId = principalDetails.getUsername();
         CommentDto.Response response = commentService.update(commentId, userId, req);
         return ResponseEntity.ok(response);
     }
 
     @DeleteMapping("/{commentId}")
     public ResponseEntity<Void> delete(
-            @PathVariable String targetId, // 경로 일관성 유지
-            @PathVariable String commentId,
-            @RequestParam String userId) { // TODO: JWT 인증 도입 시 Principal 객체 등으로 대체
+            Authentication authentication,
+            @PathVariable String commentId) {
+        PrincipalDetails principalDetails = (PrincipalDetails) authentication.getPrincipal();
+        String userId = principalDetails.getUsername();
         commentService.deleteSoft(commentId, userId);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<List<CommentDto.Response>> searchComments(
+            @RequestParam(required = false) String courseId,
+            @RequestParam(required = false) String courseSlug,
+            @RequestParam(required = false) String courseName,
+            @RequestParam(required = false) String userId,
+            @RequestParam(required = false) String username
+    ) {
+
+
+        List<CommentDto.Response> responses = commentService.searchComments(
+                courseId, courseSlug, courseName, userId, username
+        );
+        return ResponseEntity.ok(responses);
     }
 }

--- a/src/main/java/com/handongapp/cms/dto/v1/CommentDto.java
+++ b/src/main/java/com/handongapp/cms/dto/v1/CommentDto.java
@@ -56,6 +56,9 @@ public class CommentDto {
     @AllArgsConstructor
     public static class CreateRequest {
 
+        @NotBlank(message = "대상 ID는 필수입니다")
+        private String targetId;
+
         @NotBlank(message = "내용은 필수입니다")
         @Size(max = 1000, message = "내용은 1000자를 초과할 수 없습니다")
         private String content;
@@ -63,13 +66,12 @@ public class CommentDto {
         @NotBlank(message = "카테고리 ID는 필수입니다")
         private String categoryId;
 
-        public TbComment toEntity(String targetId, String userId) {
+        public TbComment toEntity(String userId) {
             TbComment comment = new TbComment();
-            comment.setTargetId(targetId);
+            comment.setTargetId(this.targetId);
             comment.setUserId(userId);
             comment.setContent(this.content);
             comment.setCategoryId(this.categoryId); 
-            // comment.setNodeDeleted(false); 
             comment.setDeleted("N"); 
             return comment;
         }
@@ -77,15 +79,11 @@ public class CommentDto {
 
     // UpdateRequest DTO
     @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class UpdateRequest {
-        private final String content;
-        private final String categoryId;
-
-        // Constructor for final fields, similar to CourseDto.UpdateRequest
-        public UpdateRequest(String content, String categoryId) {
-            this.content = content;
-            this.categoryId = categoryId;
-        }
+        private String content;
+        private String categoryId;
 
         public void applyTo(TbComment entity) {
             if (this.content != null) {

--- a/src/main/java/com/handongapp/cms/mapper/CustomQueryMapper.java
+++ b/src/main/java/com/handongapp/cms/mapper/CustomQueryMapper.java
@@ -1,0 +1,22 @@
+package com.handongapp.cms.mapper; 
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
+public interface CustomQueryMapper {
+
+    String findCourseIdBySlug(@Param("slug") String slug);
+
+    String findCourseIdByName(@Param("name") String name);
+
+    String findUserIdByUsername(@Param("username") String username);
+
+    List<String> findTargetIdsByCourseId(@Param("courseId") String courseId);
+    // 이 메소드는 주어진 courseId에 속하는 모든 Section, NodeGroup, Node의 ID를
+    // 계층적으로 탐색하여 List<String> 형태로 반환해야 합니다.
+    // 댓글의 targetId가 nodeId 또는 nodeGroupId일 수 있으므로, 이들을 모두 포함해야 합니다.
+
+}

--- a/src/main/java/com/handongapp/cms/mapper/CustomQueryMapper.java
+++ b/src/main/java/com/handongapp/cms/mapper/CustomQueryMapper.java
@@ -18,5 +18,9 @@ public interface CustomQueryMapper {
     // 이 메소드는 주어진 courseId에 속하는 모든 Section, NodeGroup, Node의 ID를
     // 계층적으로 탐색하여 List<String> 형태로 반환해야 합니다.
     // 댓글의 targetId가 nodeId 또는 nodeGroupId일 수 있으므로, 이들을 모두 포함해야 합니다.
+    
+    List<String> findTargetIdsByNodeGroupId(@Param("nodeGroupId") String nodeGroupId);
+    // 이 메소드는 주어진 nodeGroupId에 속하는 모든 Node의 ID와 nodeGroupId 자체를
+    // List<String> 형태로 반환합니다.
 
 }

--- a/src/main/java/com/handongapp/cms/repository/CommentRepository.java
+++ b/src/main/java/com/handongapp/cms/repository/CommentRepository.java
@@ -2,10 +2,12 @@ package com.handongapp.cms.repository;
 
 import com.handongapp.cms.domain.TbComment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.repository.query.Param;
 
 @Repository
 public interface CommentRepository extends JpaRepository<TbComment, String> {
@@ -13,4 +15,15 @@ public interface CommentRepository extends JpaRepository<TbComment, String> {
     List<TbComment> findByTargetIdAndDeleted(String targetId, String deleted);
     Optional<TbComment> findByUserIdAndTargetIdAndDeleted(String userId, String targetId, String deleted);
     Optional<TbComment> findByIdAndDeleted(String id, String deleted);
+
+    @Query("SELECT c FROM TbComment c WHERE " +
+           "((:targetIds) IS NULL OR c.targetId IN (:targetIds)) AND " +
+           "(:userId IS NULL OR c.userId = :userId) AND " +
+           "c.deleted = :deletedStatus " +
+           "ORDER BY c.createdAt DESC")
+    List<TbComment> findCommentsByCriteria(
+            @Param("targetIds") List<String> targetIds,
+            @Param("userId") String userId,
+            @Param("deletedStatus") String deletedStatus
+    );
 }

--- a/src/main/java/com/handongapp/cms/service/CommentService.java
+++ b/src/main/java/com/handongapp/cms/service/CommentService.java
@@ -16,6 +16,7 @@ public interface CommentService {
             String courseId,
             String courseSlug,
             String courseName,
+            String nodeGroupId,
             String filterUserId,
             String username
     );

--- a/src/main/java/com/handongapp/cms/service/CommentService.java
+++ b/src/main/java/com/handongapp/cms/service/CommentService.java
@@ -5,12 +5,19 @@ import java.util.List;
 
 public interface CommentService {
 
-    CommentDto.Response create(String targetId, String userId, CommentDto.CreateRequest req);
+    CommentDto.Response create(String userId, CommentDto.CreateRequest req);
 
     CommentDto.Response update(String commentId, String userId, CommentDto.UpdateRequest req);
 
     void deleteSoft(String commentId, String userId);
-    
-    List<CommentDto.Response> listByTarget(String targetId);
+
+
+    List<CommentDto.Response> searchComments(
+            String courseId,
+            String courseSlug,
+            String courseName,
+            String filterUserId,
+            String username
+    );
     
 }

--- a/src/main/java/com/handongapp/cms/service/impl/CommentServiceImpl.java
+++ b/src/main/java/com/handongapp/cms/service/impl/CommentServiceImpl.java
@@ -3,9 +3,11 @@ package com.handongapp.cms.service.impl;
 import com.handongapp.cms.domain.TbComment;
 import com.handongapp.cms.dto.v1.CommentDto;
 import com.handongapp.cms.repository.CommentRepository;
+import com.handongapp.cms.mapper.CustomQueryMapper;
 import com.handongapp.cms.service.CommentService;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,7 +16,10 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class CommentServiceImpl implements CommentService {
+
+    private final CustomQueryMapper customQueryMapper;
 
     private final CommentRepository commentRepository;
     private static final String DELETED_STATUS_NO = "N";
@@ -22,8 +27,10 @@ public class CommentServiceImpl implements CommentService {
 
     @Override
     @Transactional
-    public CommentDto.Response create(String targetId, String userId, CommentDto.CreateRequest req) {
-        TbComment entity = req.toEntity(targetId, userId);
+    public CommentDto.Response create(String userId, CommentDto.CreateRequest req) {
+        // todo userId로 요청하는 targetid (nodeId가 속한 course가 속한 clubmember 인지 확인, 아닌 경우엔 exception)
+
+        TbComment entity = req.toEntity(userId);
         TbComment savedComment = commentRepository.save(entity);
         return CommentDto.Response.from(savedComment);
     }
@@ -57,10 +64,84 @@ public class CommentServiceImpl implements CommentService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<CommentDto.Response> listByTarget(String targetId) {
-        return commentRepository.findByTargetIdAndDeleted(targetId, DELETED_STATUS_NO)
-                .stream()
+    public List<CommentDto.Response> searchComments(
+            String courseId,
+            String courseSlug,
+            String courseName,
+            String filterUserId,
+            String username
+    ) {
+
+        // 1. 코스 파라미터 유효성 검사
+        int courseParamsProvided = 0;
+        if (courseId != null && !courseId.trim().isEmpty()) courseParamsProvided++;
+        if (courseSlug != null && !courseSlug.trim().isEmpty()) courseParamsProvided++;
+        if (courseName != null && !courseName.trim().isEmpty()) courseParamsProvided++;
+        
+        if (courseParamsProvided > 1) {
+            String errorMsg = "courseId, courseSlug, courseName 중 하나만 입력해주세요.";
+            log.error(errorMsg);
+            throw new IllegalArgumentException(errorMsg);
+        }
+        
+        // 2. 사용자 파라미터 유효성 검사
+        int userParamsProvided = 0;
+        if (filterUserId != null && !filterUserId.trim().isEmpty()) userParamsProvided++;
+        if (username != null && !username.trim().isEmpty()) userParamsProvided++;
+        
+        if (userParamsProvided > 1) {
+            String errorMsg = "filterUserId, username 중 하나만 입력해주세요.";
+            log.error(errorMsg);
+            throw new IllegalArgumentException(errorMsg);
+        }
+        
+        // 3. 코스 ID 해석
+        String resolvedCourseId = null;
+        if (courseId != null && !courseId.trim().isEmpty()) {
+            resolvedCourseId = courseId;
+        } else if (courseSlug != null && !courseSlug.trim().isEmpty()) {
+            resolvedCourseId = customQueryMapper.findCourseIdBySlug(courseSlug);
+            if (resolvedCourseId == null) {
+                String errorMsg = "다음 slug에 해당하는 코스를 찾을 수 없습니다: " + courseSlug;
+                log.error(errorMsg);
+                throw new EntityNotFoundException(errorMsg);
+            }
+        } else if (courseName != null && !courseName.trim().isEmpty()) {
+            resolvedCourseId = customQueryMapper.findCourseIdByName(courseName);
+            if (resolvedCourseId == null) {
+                String errorMsg = "다음 이름에 해당하는 코스를 찾을 수 없습니다: " + courseName;
+                log.error(errorMsg);
+                throw new EntityNotFoundException(errorMsg);
+            }
+        }
+        
+        // 4. 코스 대상 ID(targetIds) 조회
+        List<String> targetIdsForQuery = null;
+        if (resolvedCourseId != null && !resolvedCourseId.isEmpty()) {
+            targetIdsForQuery = customQueryMapper.findTargetIdsByCourseId(resolvedCourseId);
+        }
+
+        // 5. 사용자 ID 해석
+        String resolvedUserId = null;
+        if (filterUserId != null && !filterUserId.trim().isEmpty()) {
+            resolvedUserId = filterUserId;
+        } else if (username != null && !username.trim().isEmpty()) {
+            resolvedUserId = customQueryMapper.findUserIdByUsername(username);
+            if (resolvedUserId == null) {
+                String errorMsg = "다음 사용자 이름에 해당하는 사용자를 찾을 수 없습니다: " + username;
+                log.error(errorMsg);
+                throw new EntityNotFoundException(errorMsg);
+            }
+        } 
+        
+        // deleted 상태는 'N'을 사용 (삭제되지 않은 상태)
+        List<TbComment> comments = commentRepository.findCommentsByCriteria(targetIdsForQuery, resolvedUserId, "N");
+        
+        // 7. DTO 변환 및 반환
+        List<CommentDto.Response> responseDtos = comments.stream()
                 .map(CommentDto.Response::from)
                 .collect(Collectors.toList());
+        
+        return responseDtos;
     }
 }

--- a/src/main/java/com/handongapp/cms/service/impl/CommentServiceImpl.java
+++ b/src/main/java/com/handongapp/cms/service/impl/CommentServiceImpl.java
@@ -5,7 +5,8 @@ import com.handongapp.cms.dto.v1.CommentDto;
 import com.handongapp.cms.repository.CommentRepository;
 import com.handongapp.cms.mapper.CustomQueryMapper;
 import com.handongapp.cms.service.CommentService;
-import jakarta.persistence.EntityNotFoundException;
+import com.handongapp.cms.exception.data.NotFoundException;
+import com.handongapp.cms.exception.auth.NoAuthorizationException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -40,10 +41,10 @@ public class CommentServiceImpl implements CommentService {
     @Transactional
     public CommentDto.Response update(String commentId, String userId, CommentDto.UpdateRequest req) {
         TbComment entity = commentRepository.findByIdAndDeleted(commentId, DELETED_STATUS_NO)
-                .orElseThrow(() -> new EntityNotFoundException("수정할 댓글을 찾을 수 없습니다. ID: " + commentId));
+                .orElseThrow(() -> new NotFoundException("수정할 댓글을 찾을 수 없습니다. ID: " + commentId));
 
         if (!entity.getUserId().equals(userId)) {
-            throw new RuntimeException("댓글을 수정할 권한이 없습니다.");
+            throw new NoAuthorizationException("댓글을 수정할 권한이 없습니다.");
         }
 
         req.applyTo(entity);
@@ -54,7 +55,7 @@ public class CommentServiceImpl implements CommentService {
     @Transactional
     public void deleteSoft(String commentId, String userId) {
         TbComment entity = commentRepository.findByIdAndDeleted(commentId, DELETED_STATUS_NO)
-                .orElseThrow(() -> new EntityNotFoundException("삭제할 댓글을 찾을 수 없습니다. ID: " + commentId));
+                .orElseThrow(() -> new NotFoundException("삭제할 댓글을 찾을 수 없습니다. ID: " + commentId));
 
         if (!entity.getUserId().equals(userId)) {
             throw new RuntimeException("댓글을 삭제할 권한이 없습니다.");
@@ -132,7 +133,7 @@ public class CommentServiceImpl implements CommentService {
     private String findCourseIdBySlug(String slug) {
         String courseId = customQueryMapper.findCourseIdBySlug(slug);
         if (courseId == null) {
-            throwEntityNotFoundException("다음 slug에 해당하는 코스를 찾을 수 없습니다: " + slug);
+            throwNotFoundException("다음 slug에 해당하는 코스를 찾을 수 없습니다: " + slug);
         }
         return courseId;
     }
@@ -140,7 +141,7 @@ public class CommentServiceImpl implements CommentService {
     private String findCourseIdByName(String name) {
         String courseId = customQueryMapper.findCourseIdByName(name);
         if (courseId == null) {
-            throwEntityNotFoundException("다음 이름에 해당하는 코스를 찾을 수 없습니다: " + name);
+            throwNotFoundException("다음 이름에 해당하는 코스를 찾을 수 없습니다: " + name);
         }
         return courseId;
     }
@@ -148,14 +149,14 @@ public class CommentServiceImpl implements CommentService {
     private String findUserIdByUsername(String username) {
         String userId = customQueryMapper.findUserIdByUsername(username);
         if (userId == null) {
-            throwEntityNotFoundException("다음 사용자 이름에 해당하는 사용자를 찾을 수 없습니다: " + username);
+            throwNotFoundException("다음 사용자 이름에 해당하는 사용자를 찾을 수 없습니다: " + username);
         }
         return userId;
     }
 
-    private void throwEntityNotFoundException(String message) {
+    private void throwNotFoundException(String message) {
         log.error(message);
-        throw new EntityNotFoundException(message);
+        throw new NotFoundException(message);
     }
 
     private List<String> resolveTargetIds(String courseId) {

--- a/src/main/java/com/handongapp/cms/service/impl/CommentServiceImpl.java
+++ b/src/main/java/com/handongapp/cms/service/impl/CommentServiceImpl.java
@@ -58,7 +58,7 @@ public class CommentServiceImpl implements CommentService {
                 .orElseThrow(() -> new NotFoundException("삭제할 댓글을 찾을 수 없습니다. ID: " + commentId));
 
         if (!entity.getUserId().equals(userId)) {
-            throw new RuntimeException("댓글을 삭제할 권한이 없습니다.");
+            throw new NoAuthorizationException("댓글을 삭제할 권한이 없습니다.");
         }
 
         entity.setDeleted(DELETED_STATUS_YES);

--- a/src/main/resources/mapper/ClubMapper.xml
+++ b/src/main/resources/mapper/ClubMapper.xml
@@ -67,53 +67,57 @@
         ORDER BY s.`order`, ng.`order`, n.`order`
     </select>
     <select id="getCoursesByClubSlugAsJson" resultType="string">
-        SELECT JSON_ARRAYAGG(
-            JSON_OBJECT(
-                'id',   c.id,
-                'title',c.title,
-                'slug', c.slug,
-                'description', c.description,
-                'pictureUrl', c.picture_url,
-                'isVisible', c.is_visible,
-                'creatorUserId', c.user_id,
-                'sections', (
-                    SELECT JSON_ARRAYAGG(
-                        JSON_OBJECT(
-                            'id',s.id,
-                            'title',s.title,
-                            'description', s.description,
-                            'order', s.order,
-                            'nodeGroups',(
-                                SELECT JSON_ARRAYAGG(
-                                    JSON_OBJECT(
-                                        'id',g.id,
-                                        'title',g.title,
-                                        'order', g.order,
-                                        'nodes',(
-                                            SELECT JSON_ARRAYAGG(
-                                                JSON_OBJECT(
-                                                    'id',n.id,
-                                                    'type',n.type,
-                                                    'data',n.data,
-                                                    'order', n.order,
-                                                    'isCommentPermitted', n.is_comment_permitted = b'1'
+        SELECT 
+            COALESCE( -- 가장 바깥쪽 JSON_ARRAYAGG 결과가 NULL이면 빈 배열 '[]'을 반환
+                JSON_ARRAYAGG(
+                    JSON_OBJECT(
+                        'id',   c.id,
+                        'title',c.title,
+                        'slug', c.slug,
+                        'description', c.description,
+                        'pictureUrl', c.picture_url,
+                        'isVisible', c.is_visible,
+                        'creatorUserId', c.user_id,
+                        'sections', (
+                            SELECT JSON_ARRAYAGG(
+                                JSON_OBJECT(
+                                    'id',s.id,
+                                    'title',s.title,
+                                    'description', s.description,
+                                    'order', s.order,
+                                    'nodeGroups',(
+                                        SELECT JSON_ARRAYAGG(
+                                            JSON_OBJECT(
+                                                'id',g.id,
+                                                'title',g.title,
+                                                'order', g.order,
+                                                'nodes',(
+                                                    SELECT JSON_ARRAYAGG(
+                                                        JSON_OBJECT(
+                                                            'id',n.id,
+                                                            'type',n.type,
+                                                            'data',n.data,
+                                                            'order', n.order,
+                                                            'isCommentPermitted', n.is_comment_permitted = b'1'
+                                                        )
+                                                    ) FROM tb_node n
+                                                    WHERE n.node_group_id = g.id AND n.deleted = 'N'
+                                                    ORDER BY n.order ASC
                                                 )
-                                            ) FROM tb_node n
-                                            WHERE n.node_group_id = g.id AND n.deleted = 'N'
-                                            ORDER BY n.order ASC
-                                        )
+                                            )
+                                        ) FROM tb_node_group g
+                                        WHERE g.section_id = s.id AND g.deleted = 'N'
+                                        ORDER BY g.order ASC
                                     )
-                                ) FROM tb_node_group g
-                                WHERE g.section_id = s.id AND g.deleted = 'N'
-                                ORDER BY g.order ASC
-                            )
+                                )
+                            ) FROM tb_section s
+                            WHERE s.course_id = c.id AND s.deleted = 'N'
+                            ORDER BY s.order ASC
                         )
-                    ) FROM tb_section s
-                    WHERE s.course_id = c.id AND s.deleted = 'N'
-                    ORDER BY s.order ASC
-                )
+                    )
+                ),
+                JSON_ARRAY() -- tb_course가 없을 경우 빈 배열
             )
-        )
         FROM tb_course c
         JOIN tb_club club ON c.club_id = club.id
         WHERE club.slug = #{clubSlug} AND c.deleted = 'N' AND club.deleted = 'N'

--- a/src/main/resources/mapper/CustomQueryMapper.xml
+++ b/src/main/resources/mapper/CustomQueryMapper.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.handongapp.cms.mapper.CustomQueryMapper">
+
+    <select id="findCourseIdBySlug" resultType="string">
+        SELECT id 
+        FROM tb_course 
+        WHERE slug = #{slug}
+    </select>
+
+    <select id="findCourseIdByName" resultType="string">
+        SELECT id 
+        FROM tb_course 
+        WHERE name = #{name}
+    </select>
+
+    <select id="findUserIdByUsername" resultType="string">
+        SELECT id 
+        FROM tb_user 
+        WHERE username = #{username}
+    </select>
+
+    <select id="findTargetIdsByCourseId" resultType="string">
+        <!-- 
+            주어진 courseId에 해당하는 모든 NodeGroup ID와 Node ID를 검색합니다.
+            댓글의 targetId는 NodeGroup ID 또는 Node ID일 수 있습니다.
+        -->
+        SELECT ng.id AS target_id
+        FROM tb_course c
+        JOIN tb_section s ON c.id = s.course_id 
+        JOIN tb_node_group ng ON s.id = ng.section_id
+        WHERE c.id = #{courseId}
+
+        UNION
+
+        SELECT n.id AS target_id
+        FROM tb_course c
+        JOIN tb_section s ON c.id = s.course_id
+        JOIN tb_node_group ng ON s.id = ng.section_id
+        JOIN tb_node n ON ng.id = n.node_group_id
+        WHERE c.id = #{courseId}
+    </select>
+
+</mapper>

--- a/src/main/resources/mapper/CustomQueryMapper.xml
+++ b/src/main/resources/mapper/CustomQueryMapper.xml
@@ -7,19 +7,19 @@
     <select id="findCourseIdBySlug" resultType="string">
         SELECT id 
         FROM tb_course 
-        WHERE slug = #{slug}
+        WHERE slug = #{slug} AND deleted = 'N'
     </select>
 
     <select id="findCourseIdByName" resultType="string">
         SELECT id 
         FROM tb_course 
-        WHERE name = #{name}
+        WHERE name = #{name} AND deleted = 'N'
     </select>
 
     <select id="findUserIdByUsername" resultType="string">
         SELECT id 
         FROM tb_user 
-        WHERE username = #{username}
+        WHERE username = #{username} AND deleted = 'N'
     </select>
 
     <select id="findTargetIdsByCourseId" resultType="string">
@@ -31,7 +31,9 @@
         FROM tb_course c
         JOIN tb_section s ON c.id = s.course_id 
         JOIN tb_node_group ng ON s.id = ng.section_id
-        WHERE c.id = #{courseId}
+        WHERE c.id = #{courseId} AND c.deleted = 'N'
+        AND s.deleted = 'N' 
+        AND ng.deleted = 'N'
 
         UNION
 
@@ -40,7 +42,10 @@
         JOIN tb_section s ON c.id = s.course_id
         JOIN tb_node_group ng ON s.id = ng.section_id
         JOIN tb_node n ON ng.id = n.node_group_id
-        WHERE c.id = #{courseId}
+        WHERE c.id = #{courseId} AND c.deleted = 'N'
+        AND s.deleted = 'N' 
+        AND ng.deleted = 'N'
+        AND n.deleted = 'N'
     </select>
     
     <select id="findTargetIdsByNodeGroupId" resultType="string">
@@ -54,7 +59,7 @@
         
         SELECT n.id AS target_id
         FROM tb_node n
-        WHERE n.node_group_id = #{nodeGroupId}
+        WHERE n.node_group_id = #{nodeGroupId} AND n.deleted = 'N'
     </select>
 
 </mapper>

--- a/src/main/resources/mapper/CustomQueryMapper.xml
+++ b/src/main/resources/mapper/CustomQueryMapper.xml
@@ -42,5 +42,19 @@
         JOIN tb_node n ON ng.id = n.node_group_id
         WHERE c.id = #{courseId}
     </select>
+    
+    <select id="findTargetIdsByNodeGroupId" resultType="string">
+        <!-- 
+            주어진 nodeGroupId에 해당하는 Node ID들과 nodeGroupId 자체를 검색합니다.
+            댓글의 targetId는 NodeGroup ID 또는 Node ID일 수 있습니다.
+        -->
+        SELECT #{nodeGroupId} AS target_id
+        
+        UNION
+        
+        SELECT n.id AS target_id
+        FROM tb_node n
+        WHERE n.node_group_id = #{nodeGroupId}
+    </select>
 
 </mapper>

--- a/src/main/resources/mapper/ProgramMapper.xml
+++ b/src/main/resources/mapper/ProgramMapper.xml
@@ -167,6 +167,15 @@
                                         'courseId', c.id,
                                         'courseTitle', c.title,
                                         'courseSlug', c.slug,
+                                        'nodeGroupCount', (
+                                            SELECT COUNT(*)
+                                            FROM tb_node_group ng
+                                            WHERE ng.section_id IN (
+                                                SELECT s.id
+                                                FROM tb_section s
+                                                WHERE s.course_id = c.id AND s.deleted = 'N'
+                                            ) AND ng.deleted = 'N'
+                                        ),
                                         'nodeGroups', IFNULL(
                                             (SELECT JSON_ARRAYAGG(
                                                 JSON_OBJECT(


### PR DESCRIPTION
## 📌 관련 이슈
- Resolves #127 
- Resolves #137
___ 

## ✨ 작업 내용
comment에 관한 CRUD api 완성
___ 

## 🔎 세부 설명
search endpoint의 경우 : 
  - courseId or courseSlug or courseName (3중 하나만 가능, 필수 아님)
  - userid or username (2중 하나만 가능, 필수 아님)
  - 아무것도 제공하지 않는 경우엔 모든 댓글을 조회함
___

## 🧪 테스트
- [x] bruno으로 api 테스트


___ 

## ➕ 기타
- 기존에 발생한 clubMapper에 있는 bug를 수정함 (null case에 대해 빈 array를 반환하도록 설정)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **신규 기능**
  - 다양한 조건(코스 ID, 슬러그, 이름, 노드 그룹 ID, 사용자 ID, 사용자명)으로 댓글을 검색할 수 있는 기능이 추가되었습니다.

- **기능 개선**
  - 댓글 생성, 수정, 삭제 시 사용자 인증이 자동으로 처리되어 별도의 userId 입력이 필요하지 않습니다.
  - 댓글 생성 시 targetId를 요청 본문에 포함하도록 변경되었습니다.
  - 기존의 코스별 댓글 목록 조회 기능이 제거되고, 더 유연한 검색 기능으로 대체되었습니다.
  - 댓글 API 경로가 단순화되어 URL 및 쿼리 파라미터가 정리되었습니다.

- **버그 수정**
  - 댓글 관련 API에서 불필요한 쿼리 파라미터 및 URL 경로가 정리되었습니다.

- **기타**
  - 검색 및 데이터 조회의 정확성과 유연성을 높이기 위한 내부 쿼리, 매퍼, 예외 처리 및 로깅 기능이 추가 및 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->