### PR TITLE
[BE/FEAT] DownloadUrlWithOriginalFileName 구현

### DIFF
--- a/src/main/java/com/handongapp/cms/service/PresignedUrlService.java
+++ b/src/main/java/com/handongapp/cms/service/PresignedUrlService.java
@@ -9,4 +9,5 @@ import java.time.Duration;
 public interface PresignedUrlService {
     S3Dto.UploadUrlResponse generateNodeFileUploadUrl(S3Dto.NodeFileUploadUrlRequest request, String userId);
     URL generateDownloadUrl(String key, Duration duration);
+    URL generateDownloadUrlWithOriginalFileName(String key, String originalFileName, Duration duration);
 }

--- a/src/main/java/com/handongapp/cms/service/impl/NodeGroupServiceImpl.java
+++ b/src/main/java/com/handongapp/cms/service/impl/NodeGroupServiceImpl.java
@@ -99,9 +99,32 @@ public class NodeGroupServiceImpl implements NodeGroupService {
                             if (fileNode.has("fileKey")
                                     && fileNode.has("status")
                                     && "UPLOADED".equals(fileNode.get("status").asText())) {
+
                                 String fileKey = fileNode.get("fileKey").asText();
-                                String presignedUrl = presignedUrlService.generateDownloadUrlWithOriginalFileName(fileKey, fileNode.get("originalFileName").asText(), Duration.ofHours(24)).toString();
-                                ((ObjectNode) fileNode).put("presignedUrl", presignedUrl);
+
+                                // originalFileName이 있는지와 null/빈문자열 여부를 안전하게 확인
+                                if (fileNode.has("originalFileName")) {
+                                    String originalFileName = fileNode.get("originalFileName").asText();
+                                    String presignedUrl;
+                                    if (originalFileName != null && !originalFileName.trim().isEmpty()) {
+                                        // originalFileName이 있으면 다운로드 URL 생성
+                                        presignedUrl = presignedUrlService
+                                                .generateDownloadUrlWithOriginalFileName(fileKey, originalFileName, Duration.ofHours(24))
+                                                .toString();
+                                    } else {
+                                        // originalFileName이 비어있으면 기본 presigned URL 생성
+                                        presignedUrl = presignedUrlService
+                                                .generateDownloadUrl(fileKey, Duration.ofHours(24))
+                                                .toString();
+                                    }
+                                    ((ObjectNode) fileNode).put("presignedUrl", presignedUrl);
+                                } else {
+                                    // originalFileName이 아예 없으면 기본 presigned URL 생성
+                                    String presignedUrl = presignedUrlService
+                                            .generateDownloadUrl(fileKey, Duration.ofHours(24))
+                                            .toString();
+                                    ((ObjectNode) fileNode).put("presignedUrl", presignedUrl);
+                                }
                             }
                             ((ObjectNode) fileNode).remove("fileKey");
                         }

--- a/src/main/java/com/handongapp/cms/service/impl/NodeGroupServiceImpl.java
+++ b/src/main/java/com/handongapp/cms/service/impl/NodeGroupServiceImpl.java
@@ -100,7 +100,7 @@ public class NodeGroupServiceImpl implements NodeGroupService {
                                     && fileNode.has("status")
                                     && "UPLOADED".equals(fileNode.get("status").asText())) {
                                 String fileKey = fileNode.get("fileKey").asText();
-                                String presignedUrl = presignedUrlService.generateDownloadUrl(fileKey, Duration.ofHours(24)).toString();
+                                String presignedUrl = presignedUrlService.generateDownloadUrlWithOriginalFileName(fileKey, fileNode.get("originalFileName").asText(), Duration.ofHours(24)).toString();
                                 ((ObjectNode) fileNode).put("presignedUrl", presignedUrl);
                             }
                             ((ObjectNode) fileNode).remove("fileKey");

--- a/src/main/java/com/handongapp/cms/service/impl/NodeGroupServiceImpl.java
+++ b/src/main/java/com/handongapp/cms/service/impl/NodeGroupServiceImpl.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.handongapp.cms.domain.TbNodeGroup;
 import com.handongapp.cms.domain.TbSection;
 import com.handongapp.cms.dto.v1.NodeGroupDto;
+import com.handongapp.cms.exception.file.PresignedUrlCreationException;
 import com.handongapp.cms.repository.NodeGroupRepository;
 import com.handongapp.cms.repository.SectionRepository;
 import com.handongapp.cms.service.NodeGroupService;
@@ -122,7 +123,10 @@ public class NodeGroupServiceImpl implements NodeGroupService {
                 }
             }
             return objectMapper.writeValueAsString(root);
-        } catch (Exception e) {
+        } catch (PresignedUrlCreationException e){
+            throw e;
+        }
+        catch (Exception e) {
             throw new IllegalStateException("NodeGroup JSON 파싱/직렬화에 실패했습니다.", e);
         }
     }

--- a/src/main/java/com/handongapp/cms/service/impl/PresignedUrlServiceImpl.java
+++ b/src/main/java/com/handongapp/cms/service/impl/PresignedUrlServiceImpl.java
@@ -201,13 +201,12 @@ public class PresignedUrlServiceImpl implements PresignedUrlService {
             throw new PresignedUrlCreationException("Download Presigned URL 생성 중 오류가 발생했습니다: " + e.getMessage(), e);
         }
     }
-
     /**
      * S3 Presigned URL을 생성하여 파일을 다운로드할 수 있는 링크를 반환합니다.
      * <p>
      * 이 메소드는 주어진 S3 key와 원본 파일명을 기반으로, presigned URL을 생성합니다.
      * 다운로드 시 브라우저에서 파일 이름을 {@code originalFileName}으로 표시할 수 있도록
-     * {@code Content-Disposition: attachment} 헤더를 설정합니다.
+     * {@code Content-Disposition: attachment} 헤더를 RFC 6266/5987 방식으로 설정합니다.
      * <p>
      * 만약 {@code duration}이 null로 주어지면, 기본 서명 만료 시간 {@code signatureDuration}을 사용합니다.
      *
@@ -215,7 +214,7 @@ public class PresignedUrlServiceImpl implements PresignedUrlService {
      * @param originalFileName 사용자에게 표시될 원본 파일 이름 (필수)
      * @param duration         Presigned URL 유효 기간 (null이면 기본값 사용)
      * @return presigned URL
-     * @throws IllegalArgumentException        {@code key}가 비어있거나 null인 경우 발생합니다.
+     * @throws IllegalArgumentException        {@code key}나 {@code originalFileName}이 비어있거나 유효하지 않을 경우 발생합니다.
      * @throws PresignedUrlCreationException S3 Presigned URL 생성 중 오류가 발생할 경우 발생합니다.
      */
     @Override
@@ -223,11 +222,9 @@ public class PresignedUrlServiceImpl implements PresignedUrlService {
         if (!StringUtils.hasText(key)) {
             throw new IllegalArgumentException("파일 키는 필수입니다");
         }
-
         if (!StringUtils.hasText(originalFileName)) {
             throw new IllegalArgumentException("원본 파일명은 필수입니다");
         }
-
         if (!isValidFilename(originalFileName)) {
             throw new IllegalArgumentException("유효하지 않은 원본 파일명입니다: " + originalFileName);
         }
@@ -235,12 +232,23 @@ public class PresignedUrlServiceImpl implements PresignedUrlService {
         try {
             Duration effectiveDuration = (duration != null) ? duration : signatureDuration;
 
-            String encodedFileName = URLEncoder.encode(originalFileName, StandardCharsets.UTF_8);
+            // 위험 문자 제거 (줄바꿈, 따옴표 등)
+            String sanitizedFileName = originalFileName.replaceAll("[\r\n\"]", "_");
+
+            String contentDisposition;
+            // ASCII로 표현 가능한지 여부 확인
+            if (!StandardCharsets.US_ASCII.newEncoder().canEncode(originalFileName)) {
+                // UTF-8로 URL 인코딩된 파일명 (RFC 5987)
+                String utf8FileName = URLEncoder.encode(originalFileName, StandardCharsets.UTF_8);
+                contentDisposition = "attachment; filename=\"" + sanitizedFileName + "\"; filename*=UTF-8''" + utf8FileName;
+            } else {
+                contentDisposition = "attachment; filename=\"" + sanitizedFileName + "\"";
+            }
 
             GetObjectRequest getObjectRequest = GetObjectRequest.builder()
                     .bucket(bucket)
                     .key(key)
-                    .responseContentDisposition("attachment; filename=\"" + encodedFileName + "\"")
+                    .responseContentDisposition(contentDisposition)
                     .build();
 
             GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()

--- a/src/main/java/com/handongapp/cms/service/impl/PresignedUrlServiceImpl.java
+++ b/src/main/java/com/handongapp/cms/service/impl/PresignedUrlServiceImpl.java
@@ -224,6 +224,14 @@ public class PresignedUrlServiceImpl implements PresignedUrlService {
             throw new IllegalArgumentException("파일 키는 필수입니다");
         }
 
+        if (!StringUtils.hasText(originalFileName)) {
+            throw new IllegalArgumentException("원본 파일명은 필수입니다");
+        }
+
+        if (!isValidFilename(originalFileName)) {
+            throw new IllegalArgumentException("유효하지 않은 원본 파일명입니다: " + originalFileName);
+        }
+
         try {
             Duration effectiveDuration = (duration != null) ? duration : signatureDuration;
 

--- a/src/main/java/com/handongapp/cms/service/impl/PresignedUrlServiceImpl.java
+++ b/src/main/java/com/handongapp/cms/service/impl/PresignedUrlServiceImpl.java
@@ -28,6 +28,8 @@ import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignReques
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
 
 import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.regex.Pattern;
@@ -194,6 +196,50 @@ public class PresignedUrlServiceImpl implements PresignedUrlService {
                     .signatureDuration(effectiveDuration)
                     .getObjectRequest(getObjectRequest)
                     .build();
+            return presigner.presignGetObject(presignRequest).url();
+        } catch (Exception e) {
+            throw new PresignedUrlCreationException("Download Presigned URL 생성 중 오류가 발생했습니다: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * S3 Presigned URL을 생성하여 파일을 다운로드할 수 있는 링크를 반환합니다.
+     * <p>
+     * 이 메소드는 주어진 S3 key와 원본 파일명을 기반으로, presigned URL을 생성합니다.
+     * 다운로드 시 브라우저에서 파일 이름을 {@code originalFileName}으로 표시할 수 있도록
+     * {@code Content-Disposition: attachment} 헤더를 설정합니다.
+     * <p>
+     * 만약 {@code duration}이 null로 주어지면, 기본 서명 만료 시간 {@code signatureDuration}을 사용합니다.
+     *
+     * @param key              다운로드할 S3 객체의 키 (필수, 비어있거나 null일 수 없음)
+     * @param originalFileName 사용자에게 표시될 원본 파일 이름 (필수)
+     * @param duration         Presigned URL 유효 기간 (null이면 기본값 사용)
+     * @return presigned URL
+     * @throws IllegalArgumentException        {@code key}가 비어있거나 null인 경우 발생합니다.
+     * @throws PresignedUrlCreationException S3 Presigned URL 생성 중 오류가 발생할 경우 발생합니다.
+     */
+    @Override
+    public URL generateDownloadUrlWithOriginalFileName(String key, String originalFileName, Duration duration) {
+        if (!StringUtils.hasText(key)) {
+            throw new IllegalArgumentException("파일 키는 필수입니다");
+        }
+
+        try {
+            Duration effectiveDuration = (duration != null) ? duration : signatureDuration;
+
+            String encodedFileName = URLEncoder.encode(originalFileName, StandardCharsets.UTF_8);
+
+            GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(key)
+                    .responseContentDisposition("attachment; filename=\"" + encodedFileName + "\"")
+                    .build();
+
+            GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
+                    .signatureDuration(effectiveDuration)
+                    .getObjectRequest(getObjectRequest)
+                    .build();
+
             return presigner.presignGetObject(presignRequest).url();
         } catch (Exception e) {
             throw new PresignedUrlCreationException("Download Presigned URL 생성 중 오류가 발생했습니다: " + e.getMessage(), e);

--- a/src/main/java/com/handongapp/cms/service/impl/PresignedUrlServiceImpl.java
+++ b/src/main/java/com/handongapp/cms/service/impl/PresignedUrlServiceImpl.java
@@ -183,11 +183,11 @@ public class PresignedUrlServiceImpl implements PresignedUrlService {
      * @throws PresignedUrlCreationException 생성 실패 시 예외
      */
     public URL generateDownloadUrl(String key, Duration duration) {
-        if (!StringUtils.hasText(key)) {
-            throw new IllegalArgumentException("파일 키는 필수입니다");
-        }
-
         try {
+            if (!StringUtils.hasText(key)) {
+                throw new IllegalArgumentException("파일 키는 필수입니다");
+            }
+
             Duration effectiveDuration = (duration != null) ? duration : signatureDuration;
 
             GetObjectRequest getObjectRequest = GetObjectRequest.builder()
@@ -221,17 +221,18 @@ public class PresignedUrlServiceImpl implements PresignedUrlService {
      */
     @Override
     public URL generateDownloadUrlWithOriginalFileName(String key, String originalFileName, Duration duration) {
-        if (!StringUtils.hasText(key)) {
-            throw new IllegalArgumentException("파일 키는 필수입니다");
-        }
-        if (!StringUtils.hasText(originalFileName)) {
-            throw new IllegalArgumentException("원본 파일명은 필수입니다");
-        }
-        if (!isValidFilename(originalFileName)) {
-            throw new IllegalArgumentException("유효하지 않은 원본 파일명입니다: " + originalFileName);
-        }
-
         try {
+
+            if (!StringUtils.hasText(key)) {
+                throw new IllegalArgumentException("파일 키는 필수입니다");
+            }
+            if (!StringUtils.hasText(originalFileName)) {
+                throw new IllegalArgumentException("원본 파일명은 필수입니다");
+            }
+            if (!isValidFilename(originalFileName)) {
+                throw new IllegalArgumentException("유효하지 않은 원본 파일명입니다: " + originalFileName);
+            }
+
             Duration effectiveDuration = (duration != null) ? duration : signatureDuration;
 
             // 위험 문자 제거 (줄바꿈, 따옴표 등)


### PR DESCRIPTION
## 📌 관련 이슈
- Resolves #126

___

## ✨ 작업 내용
- PresignedUrlServiceImpl에 `generateDownloadUrlWithOriginalFileName` 메소드 추가
- NodeGroupServiceImpl에서 파일/이미지 노드의 presignedUrl 생성 시 원본 이름을 포함하도록 변경
- 이제 파일 이름에 다국어를 지원함. (원래는 영어만 가능)

___

## 🔎 세부 설명
- 기존의 `generateDownloadUrl` 메소드를 대체하여 파일 다운로드 시 Content-Disposition 헤더에 원본 파일 이름을 포함시켰습니다.
- NodeGroupServiceImpl의 `fetchAllInfo` 로직을 업데이트하여, IMAGE/FILE 노드에 presignedUrl을 생성할 때 원본 이름을 반영하도록 개선했습니다.
___

## 🧪 테스트
- [x] Bruno로 /api/v1/node-group/{id} 요청 → presignedUrl 응답 확인 (파일명=원본)
- [x] Bruno로 /api/v1/stream/{nodeId}/master.m3u8 요청 → 정상 스트리밍 응답 확인

___

## ➕ 기타
- 향후 Presigned URL 만료 시간 설정을 유연화하거나, 사용자 맞춤 다운로드 파일명을 지원하는 기능으로 확장할 수 있을 것 같습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **신규 기능**
	- 파일 다운로드 시 원본 파일 이름이 브라우저의 다운로드 창에 표시되도록 presigned URL 생성 기능이 추가되었습니다.
- **버그 수정**
	- 노드 데이터 내 파일 presigned URL 생성 방식이 개선되어, 다운로드 시 올바른 파일명이 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->