### PR TITLE
[FE]138/feat course page api

### DIFF
--- a/src/main/front/src/components/coursePage/SectionCourses.tsx
+++ b/src/main/front/src/components/coursePage/SectionCourses.tsx
@@ -14,7 +14,7 @@ import ImageIcon from "@mui/icons-material/Image";
 
 export interface Node {
   id: string;
-  type: "video" | "doc" | "quiz" | "image";
+  type: "video" | "doc" | "quiz" | "image" | "file" | "text";
   title: string;
 }
 
@@ -27,6 +27,8 @@ export interface SectionCoursesProps {
 const iconMap = {
   video: <VideoLibraryIcon />,
   doc: <DescriptionIcon />,
+  file: <DescriptionIcon />,
+  text: <DescriptionIcon />,
   quiz: <QuizIcon />,
   image: <ImageIcon />,
 };
@@ -57,22 +59,33 @@ const SectionCourses: React.FC<SectionCoursesProps> = ({
       </Typography>
 
       <List dense>
-        {nodes.map((node) => (
-          <ListItem
-            key={node.id}
-            sx={{
-              pl: 0,
-              cursor: "pointer",
-              "&:hover": { backgroundColor: "rgba(255, 255, 255, 0.1)" },
-              borderRadius: 2,
-            }}
-          >
-            <ListItemIcon sx={{ minWidth: 32 }}>
-              {iconMap[node.type]}
-            </ListItemIcon>
-            <ListItemText primary={node.title} />
+        {!nodes || nodes.length === 0 ? (
+          <ListItem sx={{ pl: 0 }}>
+            <ListItemText
+              primary="콘텐츠가 없습니다."
+              sx={{ color: "gray", pl: 0, ml: 0 }}
+            />
           </ListItem>
-        ))}
+        ) : (
+          nodes.map((node) => (
+            <ListItem
+              key={node.id}
+              sx={{
+                pl: 0,
+                cursor: "pointer",
+                "&:hover": { backgroundColor: "rgba(255, 255, 255, 0.1)" },
+                borderRadius: 2,
+                pb: 1,
+                pt: 1,
+              }}
+            >
+              <ListItemIcon sx={{ minWidth: 32 }}>
+                {iconMap[node.type] ?? <DescriptionIcon />}
+              </ListItemIcon>
+              <ListItemText primary={node.title} />
+            </ListItem>
+          ))
+        )}
       </List>
     </Paper>
   );

--- a/src/main/front/src/pages/CoursePage.tsx
+++ b/src/main/front/src/pages/CoursePage.tsx
@@ -32,7 +32,7 @@ function CoursePage() {
     <Box maxWidth={980} margin="auto" mb={10}>
       <TopCourseBanner
         title={courseData?.title ?? ""}
-        producer={courseDummyData.instructor}
+        producer={courseData?.creatorUserId ?? ""}
         courseDescription={courseData?.description ?? ""}
         image={courseData?.pictureUrl ?? ""}
         onContinue={() => alert("Continue to last lesson!")}
@@ -157,15 +157,48 @@ function CoursePage() {
 
           <Box ml={2}>
             <Box>
-              {courseDummyData.sections.map((section) => (
+              {(courseData?.sections ?? []).map((section) => (
                 <Box key={section.id} mt={1}>
                   <Section text={section.title} />
                   {section.nodeGroups.map((group) => (
                     <Box mt={1.6} key={group.id}>
                       <SectionCourses
                         title={group.title}
-                        description={group.description}
-                        nodes={group.nodes}
+                        description={section.description}
+                        nodes={
+                          Array.isArray(group.nodes)
+                            ? group.nodes.map((node) => {
+                                let title = "";
+                                switch (node.type) {
+                                  case "VIDEO":
+                                  case "IMAGE":
+                                  case "FILE":
+                                  case "TEXT":
+                                    title = node.data?.title ?? "";
+                                    break;
+                                  case "QUIZ":
+                                    title = node.data?.question ?? "";
+                                    break;
+                                  default:
+                                    title = "";
+                                }
+                                return {
+                                  id: node.id,
+                                  type:
+                                    node.type === "FILE"
+                                      ? "doc"
+                                      : (node.type.toLowerCase() as
+                                          | "video"
+                                          | "image"
+                                          | "quiz"
+                                          | "doc"
+                                          | "file"
+                                          | "text"),
+                                  title,
+                                };
+                              })
+                            : []
+                        }
                       />
                     </Box>
                   ))}

--- a/src/main/front/src/types/courseData.types.ts
+++ b/src/main/front/src/types/courseData.types.ts
@@ -1,3 +1,49 @@
+export interface CourseNodeFile {
+  path?: string;
+  fileKey?: string;
+  originalFileName?: string;
+  status?: string;
+  contentType?: string;
+}
+
+export type CourseNodeType = "VIDEO" | "IMAGE" | "QUIZ" | "FILE" | "TEXT";
+
+export interface CourseNodeData {
+  // VIDEO, IMAGE, FILE, TEXT
+  title?: string;
+  description?: string;
+  file?: CourseNodeFile;
+  // QUIZ
+  question?: string;
+  options?: string[];
+  answer?: string;
+  // TEXT
+  content?: string;
+}
+
+export interface CourseNode {
+  id: string;
+  type: CourseNodeType;
+  data: CourseNodeData;
+  order: number;
+  isCommentPermitted?: boolean;
+}
+
+export interface CourseNodeGroup {
+  id: string;
+  title: string;
+  order: number;
+  nodes: CourseNode[] | null;
+}
+
+export interface CourseSection {
+  id: string;
+  title: string;
+  description: string;
+  order: number;
+  nodeGroups: CourseNodeGroup[];
+}
+
 export interface CourseData {
   id: string;
   title: string;
@@ -6,20 +52,5 @@ export interface CourseData {
   pictureUrl: string;
   isVisible: number;
   creatorUserId: string;
-  sections: Array<{
-    id: string;
-    title: string;
-    description: string;
-    order: number;
-    nodeGroups: Array<{
-      id: string;
-      title: string;
-      order: number;
-      nodes: Array<{
-        id: string;
-        title: string;
-        order: number;
-      }> | null;
-    }>;
-  }>;
+  sections: CourseSection[];
 }


### PR DESCRIPTION
## ✅ PR 체크리스트

- [ ] 로컬 환경에서 작동 확인 (애러 없는지)
- [ ] 제목에 작업 파트 추가 ([FE] 또는 [BE] Prefix 추가)
___ 

## ✨ 작업 내용
- course 페이지 리스트 API 추가

<img width="767" alt="image" src="https://github.com/user-attachments/assets/6653adc6-b534-4dc4-89d5-cebb7f9cef76" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 파일 및 텍스트 유형의 콘텐츠 지원이 추가되었습니다.
- **버그 수정**
  - 콘텐츠가 없을 때 "콘텐츠가 없습니다."라는 안내 메시지가 회색으로 표시됩니다.
- **스타일**
  - 콘텐츠 목록 아이템에 상하 패딩이 추가되어 시각적 일관성이 향상되었습니다.
- **문서화**
  - 강의 콘텐츠 데이터 구조가 명확하게 정의되어 타입 안정성이 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->