### PR TITLE
Feat/144 progress api

### DIFF
--- a/.bruno/v1/progress/end checking progress.bru
+++ b/.bruno/v1/progress/end checking progress.bru
@@ -1,0 +1,17 @@
+meta {
+  name: end checking progress
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{BASE_URL_LOCAL}}/api/v1/progress/start
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "nodeGroupId":"52e307449f054159a7878de55751d8a8"
+  }
+}

--- a/.bruno/v1/progress/start checking progress.bru
+++ b/.bruno/v1/progress/start checking progress.bru
@@ -1,0 +1,23 @@
+meta {
+  name: start checking progress
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{BASE_URL_LOCAL}}/api/v1/progress/start
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "nodeGroupId":"52e307449f054159a7878de55751d8a8"
+  }
+  
+  // 사용자가 참가자로 등록되어 있는 프로그램에 해당하는 nodeGroupId만 가능 (아니면 필터링됩니다.)
+  // db를 직접 조작해서 자신이 프로그램 참가자인 것으로 바꿔 두어야 테스트할 수 있습니다.
+  // 진행 중인 상태인 프로그램만 진행도를 체크할 수 있습니다.
+  // 같은 중복해서 요청을 보내도 최신 확인 날짜만 바뀔 뿐, 진도 상태가 추가되거나 변경되지 않습니다.
+  
+}

--- a/src/main/java/com/handongapp/cms/controller/ProgressController.java
+++ b/src/main/java/com/handongapp/cms/controller/ProgressController.java
@@ -1,0 +1,62 @@
+package com.handongapp.cms.controller;
+
+import com.handongapp.cms.dto.ProgressDto;
+import com.handongapp.cms.exception.auth.NoAuthenticatedException;
+import com.handongapp.cms.security.PrincipalDetails;
+import com.handongapp.cms.service.ProgressService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/progress")
+public class ProgressController {
+
+    private final ProgressService progressService;
+
+    @PostMapping("/start")
+    public ResponseEntity<ProgressDto.Response> startProgress(
+            Authentication authentication, 
+            @Valid @RequestBody ProgressDto.Request request) {
+        
+        log.info("노드그룹 학습 시작: nodeGroupId={}", request.getNodeGroupId());
+        String userId = extractUserId(authentication);
+        
+        ProgressDto.Response response = progressService.startProgress(userId, request);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/end")
+    public ResponseEntity<ProgressDto.Response> endProgress(
+            Authentication authentication, 
+            @Valid @RequestBody ProgressDto.Request request) {
+        
+        log.info("노드그룹 학습 완료: nodeGroupId={}", request.getNodeGroupId());
+        String userId = extractUserId(authentication);
+        
+        ProgressDto.Response response = progressService.endProgress(userId, request);
+        return ResponseEntity.ok(response);
+    }
+
+
+    private String extractUserId(Authentication authentication) {
+        if (authentication == null || authentication.getPrincipal() == null) {
+            throw new NoAuthenticatedException("인증 정보가 없습니다");
+        }
+        if (!(authentication.getPrincipal() instanceof PrincipalDetails)) {
+            throw new IllegalStateException("잘못된 인증 타입입니다");
+        }
+        PrincipalDetails principalDetails = (PrincipalDetails) authentication.getPrincipal();
+        
+        return principalDetails.getUsername();
+    }
+}

--- a/src/main/java/com/handongapp/cms/domain/TbCourseLastView.java
+++ b/src/main/java/com/handongapp/cms/domain/TbCourseLastView.java
@@ -1,6 +1,9 @@
 package com.handongapp.cms.domain;
 
 import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 /**
  * <p>TbCourseLastView Entity – records the last node-group a user has viewed
@@ -9,6 +12,9 @@ import jakarta.persistence.*;
  * <p><b>Design Pattern:</b> Plain Old Java Object, used as a JPA Aggregate Root.</p>
  */
 @Entity
+@Getter
+@Setter
+@NoArgsConstructor
 @Table(name = "tb_course_last_view",
         indexes = {
                 @Index(columnList = "deleted")

--- a/src/main/java/com/handongapp/cms/dto/ProgressDto.java
+++ b/src/main/java/com/handongapp/cms/dto/ProgressDto.java
@@ -1,0 +1,32 @@
+package com.handongapp.cms.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+public class ProgressDto {
+    
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Request {
+        @NotBlank(message = "nodeGroupId는 필수입니다.")
+        private String nodeGroupId;
+    }
+    
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Response {
+        private String id;
+        private String nodeGroupId;
+        private String userId;
+        private String programId;
+        private String state;
+        private String message;
+    }
+}

--- a/src/main/java/com/handongapp/cms/repository/CourseLastViewRepository.java
+++ b/src/main/java/com/handongapp/cms/repository/CourseLastViewRepository.java
@@ -4,6 +4,17 @@ import com.handongapp.cms.domain.TbCourseLastView;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface CourseLastViewRepository extends JpaRepository<TbCourseLastView, String> {
+    /**
+     * 사용자와 코스에 해당하는 마지막 조회 정보 찾기
+     * 
+     * @param userId 사용자 ID
+     * @param courseId 코스 ID
+     * @param deleted 삭제 여부
+     * @return 마지막 조회 정보
+     */
+    Optional<TbCourseLastView> findByUserIdAndCourseIdAndDeleted(String userId, String courseId, String deleted);
 }

--- a/src/main/java/com/handongapp/cms/repository/NodeGroupRepository.java
+++ b/src/main/java/com/handongapp/cms/repository/NodeGroupRepository.java
@@ -18,4 +18,20 @@ public interface NodeGroupRepository extends JpaRepository<TbNodeGroup, String> 
 
     @Query("SELECT ng FROM TbNodeGroup ng WHERE ng.sectionId = :sectionId AND ng.deleted = 'N' ORDER BY ng.order ASC LIMIT 1")
     Optional<TbNodeGroup> findFirstInNextSection(@Param("sectionId") String sectionId);
+    
+    /**
+     * 노드그룹 ID로 해당 노드그룹이 속한 코스 ID를 조회
+     * 
+     * @param nodeGroupId 노드그룹 ID
+     * @param deleted 삭제 여부
+     * @return 코스 ID
+     */
+    @Query(value = 
+        "SELECT c.id FROM tb_course c " +
+        "JOIN tb_section s ON c.id = s.course_id AND s.deleted = :deleted " +
+        "JOIN tb_node_group ng ON s.id = ng.section_id AND ng.deleted = :deleted " +
+        "WHERE ng.id = :nodeGroupId AND c.deleted = :deleted", nativeQuery = true)
+    Optional<String> findCourseIdByNodeGroupId(
+        @Param("nodeGroupId") String nodeGroupId, 
+        @Param("deleted") String deleted);
 }

--- a/src/main/java/com/handongapp/cms/repository/ProgramProgressRepository.java
+++ b/src/main/java/com/handongapp/cms/repository/ProgramProgressRepository.java
@@ -2,8 +2,46 @@ package com.handongapp.cms.repository;
 
 import com.handongapp.cms.domain.TbProgramProgress;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface ProgramProgressRepository extends JpaRepository<TbProgramProgress, String> {
+    /**
+     * 사용자, 프로그램, 노드그룹에 해당하는 진행 상태 조회
+     * 
+     * @param userId 사용자 ID
+     * @param programId 프로그램 ID
+     * @param nodeGroupId 노드그룹 ID
+     * @param deleted 삭제 여부
+     * @return 프로그램 진행 상태
+     */
+    Optional<TbProgramProgress> findByUserIdAndProgramIdAndNodeGroupIdAndDeleted(
+        String userId, String programId, String nodeGroupId, String deleted);
+        
+    /**
+     * 특정 코스가 어떤 프로그램에 속해있는지 확인하는 쿼리
+     * 
+     * @param courseId 코스 ID
+     * @param userId 사용자 ID
+     * @param deleted 삭제 여부
+     * @return 프로그램 ID와 해당 프로그램이 유효한지 여부
+     */
+    @Query(value = 
+        "SELECT p.id AS programId FROM tb_program p " +
+        "JOIN tb_program_participant pp ON p.id = pp.program_id AND pp.deleted = 'N' " +
+        "JOIN tb_program_course pc ON p.id = pc.program_id AND pc.deleted = 'N' " +
+        "WHERE pc.course_id = :courseId " +
+        "AND pp.user_id = :userId " +
+        "AND p.deleted = :deleted " +
+        "AND p.start_date <= NOW() " +
+        "AND p.end_date >= NOW() " +
+        "LIMIT 1", nativeQuery = true)
+    Optional<String> findValidProgramIdByCourseIdAndUserId(
+        @Param("courseId") String courseId, 
+        @Param("userId") String userId, 
+        @Param("deleted") String deleted);
 }

--- a/src/main/java/com/handongapp/cms/service/ProgressService.java
+++ b/src/main/java/com/handongapp/cms/service/ProgressService.java
@@ -1,0 +1,10 @@
+package com.handongapp.cms.service;
+
+import com.handongapp.cms.dto.ProgressDto;
+
+public interface ProgressService {
+
+    ProgressDto.Response startProgress(String userId, ProgressDto.Request request);
+    
+    ProgressDto.Response endProgress(String userId, ProgressDto.Request request);
+}

--- a/src/main/java/com/handongapp/cms/service/impl/ProgressServiceImpl.java
+++ b/src/main/java/com/handongapp/cms/service/impl/ProgressServiceImpl.java
@@ -1,0 +1,132 @@
+package com.handongapp.cms.service.impl;
+
+import com.handongapp.cms.domain.TbCourseLastView;
+import com.handongapp.cms.domain.TbProgramProgress;
+import com.handongapp.cms.domain.enums.ProgramProgressState;
+import com.handongapp.cms.dto.ProgressDto;
+import com.handongapp.cms.exception.data.DataUpdateException;
+import com.handongapp.cms.exception.data.NotFoundException;
+import com.handongapp.cms.repository.CourseLastViewRepository;
+import com.handongapp.cms.repository.NodeGroupRepository;
+import com.handongapp.cms.repository.ProgramProgressRepository;
+import com.handongapp.cms.repository.UserRepository;
+import com.handongapp.cms.service.ProgressService;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class ProgressServiceImpl implements ProgressService {
+
+    private final UserRepository userRepository;
+    private final NodeGroupRepository nodeGroupRepository;
+    private final ProgramProgressRepository programProgressRepository;
+    private final CourseLastViewRepository courseLastViewRepository;
+    
+    @Override
+    @Transactional
+    public ProgressDto.Response startProgress(String userId, ProgressDto.Request request) {
+        return processProgress(userId, request, ProgramProgressState.IN_PROGRESS);
+    }
+
+    @Override
+    @Transactional
+    public ProgressDto.Response endProgress(String userId, ProgressDto.Request request) {
+        return processProgress(userId, request, ProgramProgressState.DONE);
+    }
+    
+    private ProgressDto.Response processProgress(String userId, ProgressDto.Request request, ProgramProgressState state) {
+        String nodeGroupId = request.getNodeGroupId();
+        
+        // 1. 사용자와 노드그룹 유효성 확인
+        userRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundException("사용자를 찾을 수 없습니다."));
+
+        nodeGroupRepository.findByIdAndDeleted(nodeGroupId, "N")
+                .orElseThrow(() -> new NotFoundException("노드그룹을 찾을 수 없습니다."));
+        
+        // 노드그룹이 속한 코스 ID 조회
+        String courseId = nodeGroupRepository.findCourseIdByNodeGroupId(nodeGroupId, "N")
+                .orElseThrow(() -> new NotFoundException("해당 노드그룹이 속한 코스를 찾을 수 없습니다."));
+        
+        // 코스 마지막 조회 정보 업데이트
+        updateCourseLastView(userId, courseId, nodeGroupId);
+        
+        // 2. 노드그룹이 속한 코스와 사용자가 참가한 프로그램에 속한 코스 중 일치하는 것 확인
+        // 프로그램의 시작일과 종료일 사이에 있는지도 확인
+        String programId = programProgressRepository.findValidProgramIdByCourseIdAndUserId(
+                        courseId, userId, "N")
+                .orElseThrow(() -> new NotFoundException("사용자가 참여 중인 유효한 프로그램에서 해당 코스를 찾을 수 없습니다."));
+        
+        // 3. 이미 같은 데이터가 있는지 확인하고, 없으면 삽입
+        TbProgramProgress progress = programProgressRepository
+                .findByUserIdAndProgramIdAndNodeGroupIdAndDeleted(userId, programId, nodeGroupId, "N")
+                .orElseGet(() -> {
+                    // 새로운 프로그램 진행 엔티티 생성
+                    TbProgramProgress newProgress = new TbProgramProgress();
+                    // ID는 AuditingFields의 @PrePersist에서 자동 생성됨
+                    newProgress.setUserId(userId);
+                    newProgress.setProgramId(programId);
+                    newProgress.setNodeGroupId(nodeGroupId);
+                    newProgress.setDeleted("N");
+                    return newProgress;
+                });
+        
+        // 상태 업데이트
+        progress.setState(state);
+        progress.setLastSeenAt(LocalDateTime.now());
+        
+        try {
+            progress = programProgressRepository.save(progress);
+            
+            // 응답 구성
+            return ProgressDto.Response.builder()
+                    .id(progress.getId())
+                    .nodeGroupId(progress.getNodeGroupId())
+                    .userId(progress.getUserId())
+                    .programId(progress.getProgramId())
+                    .state(progress.getState().name())
+                    .message("진행 상태가 업데이트 되었습니다.")
+                    .build();
+        } catch (Exception e) {
+            log.error("진행 상태 업데이트 중 오류 발생", e);
+            throw new DataUpdateException("진행 상태 업데이트 실패: " + e.getMessage());
+        }
+    }
+
+    private void updateCourseLastView(String userId, String courseId, String nodeGroupId) {
+        try {
+            // 기존 레코드 조회
+            Optional<TbCourseLastView> existingView = courseLastViewRepository
+                    .findByUserIdAndCourseIdAndDeleted(userId, courseId, "N");
+            
+            TbCourseLastView courseLastView;
+            
+            if (existingView.isPresent()) {
+                // 기존 레코드 업데이트
+                courseLastView = existingView.get();
+                courseLastView.setNodeGroupId(nodeGroupId);
+            } else {
+                // 새 레코드 생성
+                courseLastView = new TbCourseLastView();
+                courseLastView.setUserId(userId);
+                courseLastView.setCourseId(courseId);
+                courseLastView.setNodeGroupId(nodeGroupId);
+                courseLastView.setDeleted("N");
+            }
+            
+            courseLastViewRepository.save(courseLastView);
+            log.debug("코스 마지막 조회 정보 업데이트 완료: userId={}, courseId={}, nodeGroupId={}", 
+                    userId, courseId, nodeGroupId);
+        } catch (Exception e) {
+            // 진행 상태 업데이트에 영향을 주지 않도록 예외를 로깅만 하고 계속 진행
+            log.error("코스 마지막 조회 정보 업데이트 중 오류 발생: {}", e.getMessage(), e);
+        }
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 닫을 이슈 번호를 명시해주세요 
- Resolves #144 

___ 

## ✨ 작업 내용
/api/v1/progress 하위 endpoint 신설

___ 

## 🔎 세부 설명
요청 데이터는 jwt 토큰(userId를 얻기 위함)과 nodeGroupId 2개 입니다.
백엔드 로직에서 각 데이터의 유효성을 검증하고 체킹할 진도가 있는지를 종합적으로 쿼리를 통해 판단합니다. 

start의 경우
1. nodegroupid와 userid의 유효성 (존재하는지 검사한다.)
2. nodegroupid가 속한 course와 사용자 참가자로 있는 프로그램에 속한 코스 중에서 같은 코스가 있는지 확인한다. (없다면 예외 발생)
2-1. 이때 프로그램은 서버시간을 기준으로 start date와 enddate 사이에 있어야 유효한 것으로 판단한다. 
3. tb_program_progress 중에서 같은 데이터 (node_group_id, program_id, user_id) 가 같은 데이터가 없다면 IN_PROGRESS로 데이터를 삽입한다.

end의 경우는 Done으로 바꾸는 것 외에는 기능적으로 동일합니다.

추가로 course의 마지막 nodeGroupId를 사용자 별로 추적하는 테이블 또한 해당 엔드포인트를 통해 업데이트 됩니다.
___ 

## 🧪 테스트
- [x] bruno으로 api 테스트 (tb_program_participant 테이블을 직접 본인의 userId로 삽입 혹은 수정하셔야 테스트가 가능합니다.)
