### PR TITLE
[BE/FEAT] 동아리 베너 및 코스 베너, 유저 프로필 이미지다운로드

### DIFF
--- a/.bruno/v1/course/courseFectchChildren.bru
+++ b/.bruno/v1/course/courseFectchChildren.bru
@@ -11,6 +11,6 @@ get {
 }
 
 vars:pre-request {
-  clubSlug: example-club-slug
-  courseSlug: test-course-aaa
+  clubSlug: callein
+  courseSlug: test-jsr
 }

--- a/.bruno/v1/course/courseList.bru
+++ b/.bruno/v1/course/courseList.bru
@@ -15,5 +15,5 @@ headers {
 }
 
 vars:pre-request {
-  clubSlug: example-club-slug
+  clubSlug: callein
 }

--- a/src/main/java/com/handongapp/cms/dto/v1/ClubDto.java
+++ b/src/main/java/com/handongapp/cms/dto/v1/ClubDto.java
@@ -15,8 +15,7 @@ public class ClubDto {
         private String clubName;
         private String slug;
         private String description;
-        private String fileKey;
-
+        private String bannerUrl;
     }
 
     @Getter

--- a/src/main/java/com/handongapp/cms/service/ClubService.java
+++ b/src/main/java/com/handongapp/cms/service/ClubService.java
@@ -13,6 +13,4 @@ public interface ClubService {
     ClubDto.ClubProfileResDto createClub(ClubDto.ClubProfileReqDto dto);
 
     void deleteClub(String clubSlug);
-
-    void updateClubBanner(String clubId, String fileKey);
 }

--- a/src/main/java/com/handongapp/cms/service/CourseService.java
+++ b/src/main/java/com/handongapp/cms/service/CourseService.java
@@ -8,5 +8,4 @@ public interface CourseService {
     CourseDto.Response updateBySlug(String clubSlug, String courseSlug, CourseDto.UpdateRequest req);
     void deleteSoftBySlug(String slug);
     String getCourseDetailsAsJsonBySlug(String courseSlug);
-    void updateCourseBanner(String courseId, String fileKey);
 }

--- a/src/main/java/com/handongapp/cms/service/UserService.java
+++ b/src/main/java/com/handongapp/cms/service/UserService.java
@@ -15,5 +15,4 @@ public interface UserService {
     void updateUserProfileImage(UserDto.UserProfileImageReqDto reqDto, String userId);
     UserDto.UserProfileLastResDto getLastUserByNodeGroup(String userId);
     List<ProgramDto.ResponseDto> getUserPrograms(String userId);
-    void updateUserProfile(String userId, String fileKey);
 }

--- a/src/main/java/com/handongapp/cms/service/impl/ClubServiceImpl.java
+++ b/src/main/java/com/handongapp/cms/service/impl/ClubServiceImpl.java
@@ -4,12 +4,11 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.handongapp.cms.domain.TbClub;
-import com.handongapp.cms.domain.enums.FileStatus;
 import com.handongapp.cms.dto.v1.ClubDto;
-import com.handongapp.cms.exception.data.NotFoundException;
 import com.handongapp.cms.mapper.ClubMapper;
 import com.handongapp.cms.repository.ClubRepository;
 import com.handongapp.cms.service.ClubService;
+import com.handongapp.cms.service.PresignedUrlService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -17,6 +16,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.time.Duration;
 import java.util.Optional;
 
 @Service
@@ -26,6 +26,8 @@ public class ClubServiceImpl implements ClubService {
     private final ClubRepository clubRepository;
     private final ClubMapper clubMapper;
     private final ObjectMapper objectMapper;
+
+    private final PresignedUrlService presignedUrlService;
 
     private static final String DELETED_FLAG_YES = "Y";
     private static final String DELETED_FLAG_NO = "N";
@@ -151,15 +153,4 @@ public class ClubServiceImpl implements ClubService {
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "코스 JSON 파싱/직렬화에 실패했습니다.", e);
         }
     }
-
-    @Override
-    @Transactional
-    public void updateClubBanner(String clubId, String fileKey) {
-        TbClub club = clubRepository.findById(clubId)
-                .orElseThrow(() -> new NotFoundException("Club not found with id: " + clubId));
-        club.setFileKey(fileKey);
-        club.setFileStatus(FileStatus.UPLOADING);
-        clubRepository.save(club);
-    }
-
 }

--- a/src/main/java/com/handongapp/cms/service/impl/ClubServiceImpl.java
+++ b/src/main/java/com/handongapp/cms/service/impl/ClubServiceImpl.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.handongapp.cms.domain.TbClub;
+import com.handongapp.cms.domain.enums.FileStatus;
 import com.handongapp.cms.dto.v1.ClubDto;
 import com.handongapp.cms.mapper.ClubMapper;
 import com.handongapp.cms.repository.ClubRepository;
@@ -37,9 +38,11 @@ public class ClubServiceImpl implements ClubService {
         return clubRepository.findBySlugAndDeleted(clubSlug, DELETED_FLAG_NO)
                 .map(club -> {
                     String presignedUrl = null;
-                    if (StringUtils.hasText(club.getFileKey())) {
+                    if (StringUtils.hasText(club.getFileKey()) && FileStatus.UPLOADED.equals(club.getFileStatus())) {
                         // Presigned URL 생성
-                        presignedUrl = presignedUrlService.generateDownloadUrl(club.getFileKey(), Duration.ofMinutes(60)).toString();
+                        presignedUrl = presignedUrlService
+                                .generateDownloadUrl(club.getFileKey(), Duration.ofMinutes(60))
+                                .toString();
                     }
 
                     return new ClubDto.ClubProfileResDto(

--- a/src/main/java/com/handongapp/cms/service/impl/ClubServiceImpl.java
+++ b/src/main/java/com/handongapp/cms/service/impl/ClubServiceImpl.java
@@ -3,11 +3,14 @@ package com.handongapp.cms.service.impl;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.handongapp.cms.domain.TbClub;
+import com.handongapp.cms.domain.TbCourse;
 import com.handongapp.cms.domain.enums.FileStatus;
 import com.handongapp.cms.dto.v1.ClubDto;
 import com.handongapp.cms.mapper.ClubMapper;
 import com.handongapp.cms.repository.ClubRepository;
+import com.handongapp.cms.repository.CourseRepository;
 import com.handongapp.cms.service.ClubService;
 import com.handongapp.cms.service.PresignedUrlService;
 import jakarta.transaction.Transactional;
@@ -25,6 +28,7 @@ import java.util.Optional;
 public class ClubServiceImpl implements ClubService {
 
     private final ClubRepository clubRepository;
+    private final CourseRepository courseRepository;
     private final ClubMapper clubMapper;
     private final ObjectMapper objectMapper;
 
@@ -151,15 +155,36 @@ public class ClubServiceImpl implements ClubService {
 
     @Override
     public String getCoursesByClubSlugAsJson(String clubSlug) {
-        // Ensure club exists and is not deleted before fetching courses
         clubRepository.findBySlugAndDeleted(clubSlug, DELETED_FLAG_NO)
-            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "코스 정보를 조회할 클럽을 찾을 수 없습니다: " + clubSlug));
-        
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "코스 정보를 조회할 클럽을 찾을 수 없습니다: " + clubSlug));
+
         String rawJson = clubMapper.getCoursesByClubSlugAsJson(clubSlug);
 
         try {
-            JsonNode node = objectMapper.readTree(rawJson);
-            return objectMapper.writeValueAsString(node);
+            JsonNode root = objectMapper.readTree(rawJson);
+
+            if (root.isArray()) {
+                for (JsonNode courseNode : root) {
+                    String courseId = courseNode.path("id").asText(null);
+
+                    if (StringUtils.hasText(courseId)) {
+                        TbCourse course = courseRepository.findById(courseId)
+                                .orElse(null);
+
+                        if (course != null &&
+                                StringUtils.hasText(course.getFileKey()) &&
+                                FileStatus.UPLOADED.equals(course.getFileStatus())) {
+
+                            String presignedUrl = presignedUrlService.generateDownloadUrl(
+                                    course.getFileKey(), Duration.ofMinutes(60)).toString();
+
+                            ((ObjectNode) courseNode).put("pictureUrl", presignedUrl);
+                        }
+                    }
+                }
+            }
+
+            return objectMapper.writeValueAsString(root);
         } catch (JsonProcessingException e) {
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "코스 JSON 파싱/직렬화에 실패했습니다.", e);
         }

--- a/src/main/java/com/handongapp/cms/service/impl/ClubServiceImpl.java
+++ b/src/main/java/com/handongapp/cms/service/impl/ClubServiceImpl.java
@@ -35,12 +35,20 @@ public class ClubServiceImpl implements ClubService {
     @Override
     public ClubDto.ClubProfileResDto getClubProfile(String clubSlug) {
         return clubRepository.findBySlugAndDeleted(clubSlug, DELETED_FLAG_NO)
-                .map(club -> new ClubDto.ClubProfileResDto(
-                        club.getName(),
-                        club.getSlug(),
-                        club.getDescription(),
-                        club.getFileKey()
-                ))
+                .map(club -> {
+                    String presignedUrl = null;
+                    if (StringUtils.hasText(club.getFileKey())) {
+                        // Presigned URL 생성
+                        presignedUrl = presignedUrlService.generateDownloadUrl(club.getFileKey(), Duration.ofMinutes(60)).toString();
+                    }
+
+                    return new ClubDto.ClubProfileResDto(
+                            club.getName(),
+                            club.getSlug(),
+                            club.getDescription(),
+                            presignedUrl
+                    );
+                })
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "클럽을 찾을 수 없습니다: " + clubSlug));
     }
 

--- a/src/main/java/com/handongapp/cms/service/impl/CourseServiceImpl.java
+++ b/src/main/java/com/handongapp/cms/service/impl/CourseServiceImpl.java
@@ -3,9 +3,7 @@ package com.handongapp.cms.service.impl;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.handongapp.cms.domain.TbCourse;
-import com.handongapp.cms.domain.enums.FileStatus;
 import com.handongapp.cms.dto.v1.CourseDto;
-import com.handongapp.cms.exception.data.NotFoundException;
 import com.handongapp.cms.repository.ClubRepository;
 import com.handongapp.cms.repository.CourseRepository;
 import com.handongapp.cms.service.CourseService;
@@ -79,15 +77,5 @@ public class CourseServiceImpl implements CourseService {
         } catch (Exception e) {
             throw new IllegalStateException("코스 JSON 파싱/직렬화에 실패했습니다.", e);
         }
-    }
-
-    @Override
-    @Transactional
-    public void updateCourseBanner(String courseId, String fileKey) {
-        TbCourse course = courseRepository.findById(courseId)
-                .orElseThrow(() -> new NotFoundException("Course not found with id: " + courseId));
-        course.setFileKey(fileKey);
-        course.setFileStatus(FileStatus.UPLOADING);
-        courseRepository.save(course);
     }
 }

--- a/src/main/java/com/handongapp/cms/service/impl/PresignedUrlServiceImpl.java
+++ b/src/main/java/com/handongapp/cms/service/impl/PresignedUrlServiceImpl.java
@@ -73,9 +73,6 @@ public class PresignedUrlServiceImpl implements PresignedUrlService {
     private final ClubRoleRepository clubRoleRepository;
     private final FileListRepository fileListRepository;
     private final NodeService nodeService;
-    private final UserService userService;
-    private final ClubService clubService;
-    private final CourseService courseService;
 
 
     /**

--- a/src/main/java/com/handongapp/cms/service/impl/PresignedUrlServiceImpl.java
+++ b/src/main/java/com/handongapp/cms/service/impl/PresignedUrlServiceImpl.java
@@ -1,19 +1,17 @@
 package com.handongapp.cms.service.impl;
 
-import com.handongapp.cms.domain.TbClubRole;
-import com.handongapp.cms.domain.TbFileList;
-import com.handongapp.cms.domain.TbNode;
-import com.handongapp.cms.domain.TbUserClubRole;
+import com.handongapp.cms.domain.*;
 import com.handongapp.cms.domain.enums.ClubUserRole;
+import com.handongapp.cms.domain.enums.FileStatus;
 import com.handongapp.cms.dto.v1.S3Dto;
+import com.handongapp.cms.exception.data.NotFoundException;
 import com.handongapp.cms.exception.file.PresignedUrlCreationException;
 import com.handongapp.cms.mapper.NodeMapper;
-import com.handongapp.cms.repository.ClubRoleRepository;
-import com.handongapp.cms.repository.FileListRepository;
-import com.handongapp.cms.repository.UserClubRoleRepository;
+import com.handongapp.cms.repository.*;
 import com.handongapp.cms.service.*;
 import com.handongapp.cms.util.FileUtil;
 import jakarta.annotation.PreDestroy;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FilenameUtils;
@@ -68,6 +66,10 @@ public class PresignedUrlServiceImpl implements PresignedUrlService {
 
     private final NodeMapper nodeMapper;
     private final UserClubRoleRepository userClubRoleRepository;
+    private final ClubRepository clubRepository;
+    private final UserRepository userRepository;
+    private final CourseRepository courseRepository;
+
     private final ClubRoleRepository clubRoleRepository;
     private final FileListRepository fileListRepository;
     private final NodeService nodeService;
@@ -151,6 +153,7 @@ public class PresignedUrlServiceImpl implements PresignedUrlService {
      * @throws PresignedUrlCreationException    Presigned URL 생성 또는 DB 처리 중 오류가 발생할 경우 발생
      */
     @Override
+    @Transactional
     public S3Dto.UploadUrlResponse generateBannerUploadUrl(String targetType, String targetId, String originalFilename, String userId) {
         String path;
         switch (targetType) {
@@ -191,9 +194,9 @@ public class PresignedUrlServiceImpl implements PresignedUrlService {
             TbFileList savedFileList = fileListRepository.save(fileListBuilder.build());
 
             switch (targetType) {
-                case "course-banner" -> courseService.updateCourseBanner(targetId, fileKey);
-                case "club-banner" -> clubService.updateClubBanner(targetId, fileKey);
-                case "user-profile" -> userService.updateUserProfile(targetId, fileKey);
+                case "course-banner" -> updateCourseBanner(targetId, fileKey);
+                case "club-banner" -> updateClubBanner(targetId, fileKey);
+                case "user-profile" -> updateUserProfile(targetId, fileKey);
             }
 
             return S3Dto.UploadUrlResponse.builder()
@@ -427,5 +430,29 @@ public class PresignedUrlServiceImpl implements PresignedUrlService {
             case FILE -> true;  // FILE 타입에서는 모든 mimeType 허용
             default ->  false;  // TEXT, QUIZ 등은 업로드 허용하지 않음
         };
+    }
+
+    private void updateUserProfile(String userId, String fileKey) {
+        TbUser user = userRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundException("User not found with id: " + userId));
+        user.setFileKey(fileKey);
+        user.setFileStatus(FileStatus.UPLOADING);
+        userRepository.save(user);
+    }
+
+    private void updateClubBanner(String clubId, String fileKey) {
+        TbClub club = clubRepository.findById(clubId)
+                .orElseThrow(() -> new NotFoundException("Club not found with id: " + clubId));
+        club.setFileKey(fileKey);
+        club.setFileStatus(FileStatus.UPLOADING);
+        clubRepository.save(club);
+    }
+
+    private void updateCourseBanner(String courseId, String fileKey) {
+        TbCourse course = courseRepository.findById(courseId)
+                .orElseThrow(() -> new NotFoundException("Course not found with id: " + courseId));
+        course.setFileKey(fileKey);
+        course.setFileStatus(FileStatus.UPLOADING);
+        courseRepository.save(course);
     }
 }

--- a/src/main/java/com/handongapp/cms/service/impl/ProgramServiceImpl.java
+++ b/src/main/java/com/handongapp/cms/service/impl/ProgramServiceImpl.java
@@ -2,11 +2,19 @@ package com.handongapp.cms.service.impl;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.handongapp.cms.domain.TbCourse;
+import com.handongapp.cms.domain.enums.FileStatus;
 import com.handongapp.cms.mapper.ProgramMapper;
+import com.handongapp.cms.repository.CourseRepository;
+import com.handongapp.cms.service.PresignedUrlService;
 import com.handongapp.cms.service.ProgramService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.time.Duration;
 
 @Service
 @RequiredArgsConstructor
@@ -15,14 +23,37 @@ public class ProgramServiceImpl implements ProgramService {
     private final ProgramMapper programMapper;
     private final ObjectMapper objectMapper;
 
+    private final CourseRepository courseRepository;
+    private final PresignedUrlService presignedUrlService;
+
     @Override
     @Transactional(readOnly = true)
     public String getProgramDetailsWithCoursesAsJson(String clubSlug, String programSlug) {
         String rawJson = programMapper.getProgramDetailsWithCoursesAsJson(clubSlug, programSlug);
 
         try {
-            JsonNode node = objectMapper.readTree(rawJson);  // 여기서 실패하면 예외 catch로 이동
-            return objectMapper.writeValueAsString(node);
+            JsonNode root = objectMapper.readTree(rawJson);
+
+            if (root.isObject() && root.has("courses") && root.get("courses").isArray()) {
+                for (JsonNode courseNode : root.get("courses")) {
+                    String courseId = courseNode.path("id").asText(null);
+                    if (StringUtils.hasText(courseId)) {
+                        TbCourse course = courseRepository.findById(courseId)
+                                .orElse(null);
+
+                        if (course != null && StringUtils.hasText(course.getFileKey())
+                                && FileStatus.UPLOADED.equals(course.getFileStatus())) {
+                            String presignedUrl = presignedUrlService
+                                    .generateDownloadUrl(course.getFileKey(), Duration.ofMinutes(60))
+                                    .toString();
+
+                            ((ObjectNode) courseNode).put("pictureUrl", presignedUrl);
+                        }
+                    }
+                }
+            }
+
+            return objectMapper.writeValueAsString(root);
         } catch (Exception e) {
             throw new IllegalStateException("프로그램 JSON 파싱/직렬화에 실패했습니다.", e);
         }

--- a/src/main/java/com/handongapp/cms/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/handongapp/cms/service/impl/UserServiceImpl.java
@@ -25,7 +25,7 @@ import java.util.Objects;
 public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
-    private final ClubRoleRepository clubRoleRepository;
+//    private final ClubRoleRepository clubRoleRepository;
     private final UserClubRoleRepository userClubRoleRepository;
     private final UserMapper userMapper;
     private final ProgramMapper programMapper;
@@ -35,7 +35,7 @@ public class UserServiceImpl implements UserService {
                            UserClubRoleRepository userClubRoleRepository,
                            UserMapper userMapper, ProgramMapper programMapper) {
             this.userRepository = userRepository;
-            this.clubRoleRepository = clubRoleRepository;
+//            this.clubRoleRepository = clubRoleRepository;
             this.userClubRoleRepository = userClubRoleRepository;
             this.userMapper = userMapper;
         this.programMapper = programMapper;
@@ -139,15 +139,5 @@ public class UserServiceImpl implements UserService {
         public InvalidEmailDomainException(String message) {
             super(message);
         }
-    }
-
-    @Override
-    @Transactional
-    public void updateUserProfile(String userId, String fileKey) {
-        TbUser user = userRepository.findById(userId)
-                .orElseThrow(() -> new NotFoundException("User not found with id: " + userId));
-        user.setFileKey(fileKey);
-        user.setFileStatus(FileStatus.UPLOADING);
-        userRepository.save(user);
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
- Resolves #170 

## ✨ 작업 내용
- 프로그램 상세 조회 API (`getProgramDetailsWithCoursesAsJson`)에서 각 코스의 `pictureUrl`을 presigned URL로 동적으로 생성해 응답에 추가
- 각 코스의 `id`로 `TbCourse`를 찾아 `fileKey`와 `fileStatus`를 검증한 뒤 presigned URL을 동적으로 생성
- JSON 응답의 `courses` 배열 내 `pictureUrl` 필드를 presigned URL로 대체

## 🔎 세부 설명
- 프로그램 조회 시, JSON에는 `fileKey`와 `fileStatus`가 존재하지 않기 때문에, 각 코스의 `id`로 실제 DB에서 코스 정보를 조회
- 파일이 업로드 상태(UPLOADED)이고, `fileKey`가 존재하면 presigned URL을 생성
- 생성된 presigned URL은 JSON의 `pictureUrl` 필드로 주입하여, 클라이언트에서 즉시 접근할 수 있도록 지원
- 코스가 업로드 상태가 아닐 경우에는 `pictureUrl`을 주입하지 않음

## 🧪 테스트
- [x] Bruno로 프로그램 상세 조회 API 호출 후, 각 코스의 `pictureUrl`이 presigned URL로 주입되는지 확인
- [x] 파일이 업로드되지 않은 경우, `pictureUrl`이 비어있는지 확인
- [x] 코스가 없거나 존재하지 않는 경우, 정상적으로 404 응답을 받는지 확인
