### PR TITLE
Feat/105 transcode status listener

### DIFF
--- a/src/main/java/com/handongapp/cms/domain/model/VideoMetaData.java
+++ b/src/main/java/com/handongapp/cms/domain/model/VideoMetaData.java
@@ -12,4 +12,5 @@ public class VideoMetaData {
     private String originalFileName;
     private VideoStatus status;
     private String contentType;
+    private Integer progress;
 }

--- a/src/main/java/com/handongapp/cms/dto/v1/S3Dto.java
+++ b/src/main/java/com/handongapp/cms/dto/v1/S3Dto.java
@@ -62,6 +62,7 @@ public class S3Dto {
         private String fileKey;
         @NotBlank(message = "filetype 는 필수입니다")
         private String filetype;
+        private String nodeId;
     }
 
     @Data

--- a/src/main/java/com/handongapp/cms/dto/v1/S3Dto.java
+++ b/src/main/java/com/handongapp/cms/dto/v1/S3Dto.java
@@ -62,6 +62,10 @@ public class S3Dto {
         private String fileKey;
         @NotBlank(message = "filetype 는 필수입니다")
         private String filetype;
+        @NotBlank(message = "filetype 는 필수입니다")
+        private String filetype;
+        @NotBlank(message = "nodeId는 필수입니다")
+        @Pattern(regexp = "^[a-fA-F0-9]{32}$", message = "nodeId는 32자리 16진수 문자열이어야 합니다.")
         private String nodeId;
     }
 

--- a/src/main/java/com/handongapp/cms/dto/v1/S3Dto.java
+++ b/src/main/java/com/handongapp/cms/dto/v1/S3Dto.java
@@ -62,8 +62,6 @@ public class S3Dto {
         private String fileKey;
         @NotBlank(message = "filetype 는 필수입니다")
         private String filetype;
-        @NotBlank(message = "filetype 는 필수입니다")
-        private String filetype;
         @NotBlank(message = "nodeId는 필수입니다")
         @Pattern(regexp = "^[a-fA-F0-9]{32}$", message = "nodeId는 32자리 16진수 문자열이어야 합니다.")
         private String nodeId;

--- a/src/main/java/com/handongapp/cms/listener/TranscodeStatusListener.java
+++ b/src/main/java/com/handongapp/cms/listener/TranscodeStatusListener.java
@@ -1,0 +1,28 @@
+package com.handongapp.cms.listener;
+
+
+import com.handongapp.cms.service.NodeService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TranscodeStatusListener {
+
+    private final NodeService nodeService;
+
+    @RabbitListener(queues = "${rabbitmq.queue.transcode-status}")
+    public void handleTranscodeStatus(TranscodeStatusMessage message) {
+        try {
+            log.info("📡⚡️ 트랜스코딩 상태 메시지 수신 - videoId: {}, status: {}, progress: {}", message.getVideoId(), message.getStatus(), message.getProgress());
+
+            nodeService.updateVideoTranscodeStatus(message.getVideoId(), message.getStatus(), message.getProgress());
+
+        } catch (Exception e) {
+            log.error("❌ 트랜스코딩 상태 메시지 처리 실패", e);
+        }
+    }
+}

--- a/src/main/java/com/handongapp/cms/listener/TranscodeStatusMessage.java
+++ b/src/main/java/com/handongapp/cms/listener/TranscodeStatusMessage.java
@@ -1,0 +1,10 @@
+package com.handongapp.cms.listener;
+
+import lombok.Data;
+
+@Data
+public class TranscodeStatusMessage {
+    private String videoId;
+    private String status;
+    private Integer progress;
+}

--- a/src/main/java/com/handongapp/cms/service/NodeService.java
+++ b/src/main/java/com/handongapp/cms/service/NodeService.java
@@ -6,9 +6,16 @@ import java.util.List;
 
 public interface NodeService {
     NodeDto.Response create(NodeDto.CreateRequest req);
+
     NodeDto.Response get(String nodeId);
+
     List<NodeDto.Response> listByGroup(String nodeGroupId);
+
     NodeDto.Response update(String nodeId, NodeDto.UpdateRequest req);
+
     void deleteSoft(String nodeId);
+
     void updateNodeFileDataToUploading(String nodeId, String fileListId);
+
+    void updateVideoTranscodeStatus(String videoId, String status, Integer progress);
 }

--- a/src/main/java/com/handongapp/cms/service/impl/UploadNotifyServiceImpl.java
+++ b/src/main/java/com/handongapp/cms/service/impl/UploadNotifyServiceImpl.java
@@ -204,11 +204,20 @@ public class UploadNotifyServiceImpl implements UploadNotifyService {
 
         Map<String, Object> data = node.getData();
         if (data != null && data.containsKey("file")) {
-            Map<String, Object> fileMap = (Map<String, Object>) data.get("file");
+            Object fileObj = data.get("file");
+            if (!(fileObj instanceof Map<?, ?>)) {
+                log.warn("⚠️ 노드 data.file이 Map 형태가 아닙니다. nodeId: {}", dto.getNodeId());
+                return;
+            }
+
+            @SuppressWarnings("unchecked")
+            Map<String, Object> fileMap = (Map<String, Object>) fileObj;
             fileMap.put("status", VideoStatus.TRANSCODING.name());
             node.setData(data);
 
             nodeRepository.save(node);
+        } else {
+            log.warn("⚠️ 노드 data 또는 file 정보가 없습니다. nodeId: {}", dto.getNodeId());
         }
 
         try {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -41,6 +41,8 @@ cloud:
 rabbitmq:
   queue:
     transcode-request: ${TRANSCODE_REQUEST_QUEUE}
+    transcode-status: ${TRANSCODE_STATUS_QUEUE}
+
   host: ${RABBITMQ_HOST}
   port: ${RABBITMQ_PORT}
   username: ${RABBITMQ_USERNAME}


### PR DESCRIPTION
## 📌 관련 이슈
- Resolves #105

___ 

## ✨ 작업 내용
- RabbitMQ 트랜스코딩 상태 메시지 수신 리스너 추가
- 노드의 data.file.status를 TRANSCODING으로 업데이트
- 트랜스코딩 상태 진행률(progress) 업데이트
- 관련 서비스 및 로직 개선

___ 

## 🔎 세부 설명
- 업로드 완료 시 트랜스코딩 요청을 보낼 때, `TbNode.data.file.status`를 TRANSCODING으로 미리 업데이트하도록 개선했습니다.
- 트랜스코딩 상태 메시지를 수신하기 위해 `TranscodeStatusListener`를 새로 만들고, 메시지에 따라 `progress`와 `status`를 노드의 `data.file`에 업데이트하도록 처리했습니다.
- 트랜스코딩 실패/성공 시에도 적절히 반영되며, 진행률도 실시간으로 갱신됩니다.

___ 

## 🧪 테스트
- [x] Bruno로 업로드 완료 후 트랜스코딩 요청 확인
- [x] RebitMQ로 전송되는 트랜스코딩 상태 메시지 수신 확인
- [x] DB 내 노드의 `data` 필드가 올바르게 업데이트되는지 확인

___ 

## ➕ 기타
- 프론트는 폴링으로 상태를 확인예정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 영상 트랜스코딩 상태 및 진행률 정보를 수신하고 반영하는 기능이 추가되었습니다.
  - 영상 업로드 완료 시 트랜스코딩 상태가 자동으로 갱신됩니다.
  - 트랜스코딩 상태 진행률(progress) 필드가 추가되었습니다.
  - 트랜스코딩 요청에 노드 ID(nodeId) 정보가 포함됩니다.

- **기타**
  - 트랜스코딩 상태 메시지 처리를 위한 새로운 RabbitMQ 큐 설정이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->