### PR TITLE
[BE/FIX] TranscodeStatusListener 큐 자동 선언 추가로 큐 미존재 시 애플리케이션 크래시 방지

### DIFF
--- a/src/main/java/app/handong/cms/listener/TranscodeStatusListener.java
+++ b/src/main/java/app/handong/cms/listener/TranscodeStatusListener.java
@@ -1,10 +1,12 @@
 package app.handong.cms.listener;
 
-
 import app.handong.cms.service.NodeService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.context.annotation.Bean;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.amqp.core.Queue;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -18,11 +20,14 @@ public class TranscodeStatusListener {
     public void handleTranscodeStatus(TranscodeStatusMessage message) {
         try {
             log.info("📡⚡️ 트랜스코딩 상태 메시지 수신 - videoId: {}, status: {}, progress: {}", message.getVideoId(), message.getStatus(), message.getProgress());
-
             nodeService.updateVideoTranscodeStatus(message.getVideoId(), message.getStatus(), message.getProgress());
-
         } catch (Exception e) {
             log.error("❌ 트랜스코딩 상태 메시지 처리 실패", e);
         }
+    }
+
+    @Bean
+    public Queue transcodeStatusQueue(@Value("${rabbitmq.queue.transcode-status}") String name) {
+        return new Queue(name, true);
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -24,6 +24,14 @@ spring:
     port: ${RABBITMQ_PORT}
     username: ${RABBITMQ_USERNAME}
     password: ${RABBITMQ_PASSWORD}
+    listener:
+      simple:
+        missing-queues-fatal: false
+        retry:
+          enabled: true               # (선택) 연결 재시도 활성화
+          initial-interval: 2000ms
+          max-attempts: 5
+          multiplier: 2.0
 
 cloud:
   aws:


### PR DESCRIPTION
<!-- CMS PR 가이드 -->
<!-- 가이드이므로 필요없는 내용은 지워주셔도 됩니다! -->

## ✅ PR 체크리스트

- [x] 로컬 환경에서 작동 확인 (애러 없는지)
- [x] 제목에 작업 파트 추가 ([FE] 또는 [BE] Prefix 추가)

## 📌 관련 이슈
<!-- 닫을 이슈 번호를 명시해주세요 
- Resolves #이슈번호 -->

___ 

## ✨ 작업 내용

- Transcode 상태 메시지를 수신하는 `TranscodeStatusListener`에 대해 큐가 미리 존재하지 않아도 애플리케이션이 크래시되지 않도록 수정
- 큐를 자동으로 선언하는 `@Bean` 메서드 추가

___ 

## 🔎 세부 설명

- 기존에는 `@RabbitListener`가 참조하는 큐가 존재하지 않을 경우 애플리케이션이 실행 중단되는 문제가 있었음
- 이를 방지하기 위해 해당 큐를 Spring Bean으로 명시적으로 선언하여, 애플리케이션 시작 시 큐가 자동으로 생성되도록 설정함
- 이로 인해 MQ 구성 순서에 유연성이 생기며, 서비스 간 의존성 문제를 완화함

___ 

## 🧪 테스트

- [ ] RabbitMQ에 해당 큐가 미리 없는 상태에서 애플리케이션 기동 → 정상 작동 확인
- [ ] 메시지 수신 후 서비스 로직 정상 작동 확인
- [ ] 큐가 존재하는 경우에도 중복 생성 없이 정상 처리되는지 확인

___ 

## ➕ 기타

- `missing-queues-fatal: false` 설정은 현재 포함하지 않았지만, 필요 시 application.yml에 추가 고려 가능


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 트랜스코드 상태 큐가 시스템에 추가되어, 관련 메시지 처리가 가능해졌습니다.

- **버그 수정**
  - RabbitMQ 큐가 존재하지 않을 때 발생하던 치명적 오류가 방지됩니다.
  - 메시지 큐 연결 실패 시 자동 재시도 기능이 적용되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->